### PR TITLE
chore(readme): update readme to direct readers to 1.x client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # influxdb-client-go
-A home for InfluxDB’s 2.x's golang client. 
+
+A home for InfluxDB’s 2.x's golang client. This client is not compatible with InfluxDB 1.x--if you are looking for the 1.x golang client you can find it [here](https://github.com/influxdata/influxdb1-client).
 
 ## Pre-Alpha Warning!
 This is not even close to ready for prod use.


### PR DESCRIPTION
Closes #10 

This PR updates the readme to clarify to the reader that this client only works for the 2.x line, and includes a link to the 1.x client library.