### PR TITLE
chore: fix readme to point out you need go1.12 to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 A home for InfluxDB’s 2.x's golang client. This client is not compatible with InfluxDB 1.x--if you are looking for the 1.x golang client you can find it [here](https://github.com/influxdata/influxdb1-client).
 
-## Pre-Alpha Warning!
-This is not even close to ready for production use.
-Keep an eye on this repo if you are interested in the client.
-
 
 ## Example:
 ```
@@ -38,3 +34,6 @@ Keep an eye on this repo if you are interested in the client.
 
 ## Releases
 We will be using git-flow style releases, the current stable release will be listed in the master readme.
+
+## Requirements
+`influxdb-client-go` requires go version 1.12 or newer to build.


### PR DESCRIPTION
fix readme to point out you need go1.12 to build the library.

closes #11 