### PR TITLE
writer.RetryWriter implementation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -27,16 +27,17 @@ var ErrUnimplemented = errors.New("unimplemented")
 // It contains a number of contextual fields which describe the nature
 // and cause of the error
 type Error struct {
-	Code      string
-	Message   string
-	Err       string
-	Op        string
-	Line      *int32
-	MaxLength *int32
+	Code       string
+	Message    string
+	Err        string
+	Op         string
+	Line       *int32
+	MaxLength  *int32
+	RetryAfter *int32
 }
 
 // Error returns the string representation of the Error struct
-func (e Error) Error() string {
+func (e *Error) Error() string {
 	errString := fmt.Sprintf("%s (%s): %s", e.Code, e.Op, e.Message)
 	if e.Line != nil {
 		return fmt.Sprintf("%s - line[%d]", errString, e.Line)

--- a/errors.go
+++ b/errors.go
@@ -5,22 +5,46 @@ import (
 	"fmt"
 )
 
+// Error code constants copied from influxdb
+const (
+	EInternal            = "internal error"
+	ENotFound            = "not found"
+	EConflict            = "conflict"             // action cannot be performed
+	EInvalid             = "invalid"              // validation failed
+	EUnprocessableEntity = "unprocessable entity" // data type is correct, but out of range
+	EEmptyValue          = "empty value"
+	EUnavailable         = "unavailable"
+	EForbidden           = "forbidden"
+	ETooManyRequests     = "too many requests"
+	EUnauthorized        = "unauthorized"
+	EMethodNotAllowed    = "method not allowed"
+)
+
 // ErrUnimplemented is an error for when pieces of the client's functionality is unimplemented.
 var ErrUnimplemented = errors.New("unimplemented")
 
-type genericRespError struct {
+// Error is an error returned by a client operation
+// It contains a number of contextual fields which describe the nature
+// and cause of the error
+type Error struct {
 	Code      string
 	Message   string
+	Err       string
+	Op        string
 	Line      *int32
 	MaxLength *int32
 }
 
-func (g genericRespError) Error() string {
-	errString := g.Code + ": " + g.Message
-	if g.Line != nil {
-		return fmt.Sprintf("%s - line[%d]", errString, g.Line)
-	} else if g.MaxLength != nil {
-		return fmt.Sprintf("%s - maxlen[%d]", errString, g.MaxLength)
+// Error returns the string representation of the Error struct
+func (e Error) Error() string {
+	errString := fmt.Sprintf("%s (%s): %s", e.Code, e.Op, e.Message)
+	if e.Line != nil {
+		return fmt.Sprintf("%s - line[%d]", errString, e.Line)
 	}
+
+	if e.MaxLength != nil {
+		return fmt.Sprintf("%s - maxlen[%d]", errString, e.MaxLength)
+	}
+
 	return errString
 }

--- a/query.go
+++ b/query.go
@@ -91,9 +91,9 @@ func (c *Client) QueryCSV(ctx context.Context, flux string, org string, extern .
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		r := io.LimitReader(resp.Body, 1<<14) // only support errors that are 16kB long, more than that and something is probably wrong.
-		gerr := Error{Code: resp.Status}
+		gerr := &Error{Code: resp.Status}
 		if resp.ContentLength != 0 {
-			if err := json.NewDecoder(r).Decode(gerr); err != nil {
+			if err := json.NewDecoder(r).Decode(&gerr); err != nil {
 				gerr.Code = resp.Status
 				message, err := ioutil.ReadAll(r)
 				if err != nil {

--- a/query.go
+++ b/query.go
@@ -91,7 +91,7 @@ func (c *Client) QueryCSV(ctx context.Context, flux string, org string, extern .
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		r := io.LimitReader(resp.Body, 1<<14) // only support errors that are 16kB long, more than that and something is probably wrong.
-		gerr := &genericRespError{Code: resp.Status}
+		gerr := Error{Code: resp.Status}
 		if resp.ContentLength != 0 {
 			if err := json.NewDecoder(r).Decode(gerr); err != nil {
 				gerr.Code = resp.Status

--- a/write_test.go
+++ b/write_test.go
@@ -1,0 +1,131 @@
+package influxdb
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var five = int32(5)
+
+func Test_Client_Write(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		// api response
+		body       []byte
+		statusCode int
+		headers    http.Header
+		// expectations
+		count int
+		err   error
+	}{
+		{
+			name:       "successful write",
+			statusCode: http.StatusOK,
+			count:      10,
+		},
+		{
+			name:       "rate limited",
+			statusCode: http.StatusTooManyRequests,
+			headers: http.Header{
+				"Retry-After": []string{"5"},
+			},
+			err: &Error{
+				Code:       ETooManyRequests,
+				Message:    "exceeded rate limit",
+				RetryAfter: &five,
+			},
+		},
+		{
+			name:       "unavailable",
+			statusCode: http.StatusServiceUnavailable,
+			headers:    http.Header{},
+			err: &Error{
+				Code:    EUnavailable,
+				Message: "service temporarily unavailable",
+			},
+		},
+		{
+			name:       "json encoded error",
+			statusCode: http.StatusInternalServerError,
+			body:       []byte(`{"code": "internal error", "op": "doing something", "message": "foo"}`),
+			headers: http.Header{
+				"Content-Type": []string{"application/json; charset=utf-8"},
+			},
+			err: &Error{
+				Code:    EInternal,
+				Op:      "doing something",
+				Message: "foo",
+			},
+		},
+		{
+			name:       "plain text encoded error",
+			statusCode: http.StatusBadRequest,
+			body:       []byte(`payload is bad`),
+			err: &Error{
+				Code:    "400 Bad Request",
+				Message: "payload is bad",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var (
+				metrics = createTestRowMetrics(t, 10)
+				server  = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// path
+					assert.Equal(t, "/api/v2/write", r.URL.Path)
+					// headers
+					assert.Equal(t, "Token token", r.Header.Get("Authorization"))
+					assert.Equal(t, "text/plain; charset=utf-8", r.Header.Get("Content-Type"))
+					assert.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
+					// params
+					assert.Equal(t, "bucket", r.URL.Query().Get("bucket"))
+					assert.Equal(t, "org", r.URL.Query().Get("org"))
+
+					for k, v := range test.headers {
+						w.Header()[k] = v
+					}
+					w.WriteHeader(test.statusCode)
+					w.Write(test.body)
+				}))
+				client, err = New(server.URL, "token")
+			)
+
+			require.Nil(t, err)
+
+			defer func() {
+				require.Nil(t, client.Close())
+				server.Close()
+			}()
+
+			count, err := client.Write(context.TODO(), "bucket", "org", metrics...)
+			assert.Equal(t, test.err, err)
+			assert.Equal(t, test.count, count)
+		})
+	}
+}
+
+func createTestRowMetrics(t *testing.T, count int) (metrics []Metric) {
+	t.Helper()
+
+	metrics = make([]Metric, 0, count)
+	for i := 0; i < count; i++ {
+		metrics = append(metrics, NewRowMetric(
+			map[string]interface{}{
+				"some_field": "some_value",
+			},
+			"some_measurement",
+			map[string]string{
+				"some_tag": "some_value",
+			},
+			time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),
+		))
+	}
+
+	return
+}

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -85,7 +85,7 @@
 // 	// i.e. a first attempt is followed by a 1 second delay before the second attempt
 // 	// a second attempt is followed by a 2 second delay before the third attempt
 // 	var (
-// 		retryOpts = writer.RetryOption{writer.MaxAttempts(3), writer.WithBackoff(writer.LinearBackoff(time.Second))}
+// 		retryOpts = []writer.RetryOption{writer.WithMaxAttempts(3), writer.WithBackoff(writer.LinearBackoff(time.Second))}
 // 		wr        = writer.New(cli, bucket, org, writer.WithRetries(retryOpts...))
 // 	)
 // }

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -64,28 +64,29 @@
 //
 // Automatic Retries
 //
-// The write package offers automatic retry capabilities during known transient failure conditions
+// The writer package offers automatic retry capabilities during known transient failures
 // This is when the API being consumed reports "unavailable" or "too many requests" error conditions
 //
-//  import (
-//      "github.com/influxdata/influxdb-client-go"
-//      "github.com/influxdata/influxdb-client-go/writer"
-//  )
+// import (
+// 	"time"
 //
-//  func main() {
-//      var (
-//          cli, _ = influxdb.New("http://localhost:9999", "some-token")
-//          bucket = "default"
-//          org    = "influx"
-//      )
+// 	"github.com/influxdata/influxdb-client-go"
+// 	"github.com/influxdata/influxdb-client-go/writer"
+// )
 //
-//      // construct a writer with 3 maximum attempts per call to Write and linear backoff derived from number of attempts
-//      // i.e. a first attempt is followed by a 1 second delay before the second attempt
-//      // a second attempt is followed by a 2 second delay before the third attempt
-//      wr := writer.New(cli, bucket, org, writer.WithRetries(writer.MaxAttempts(3), writer.LinearBackoff(time.Second)))
+// func main() {
+// 	var (
+// 		cli, _ = influxdb.New("http://localhost:9999", "some-token")
+// 		bucket = "default"
+// 		org    = "influx"
+// 	)
 //
-//      // ...
-//      // attempts to write will automatically retry when influx API reports unavailable or while being
-//      // rate limited.
-//  }
+// 	// construct a writer with 3 maximum attempts per call to Write and linear backoff derived from number of attempts
+// 	// i.e. a first attempt is followed by a 1 second delay before the second attempt
+// 	// a second attempt is followed by a 2 second delay before the third attempt
+// 	var (
+// 		retryOpts = writer.RetryOption{writer.MaxAttempts(3), writer.WithBackoff(writer.LinearBackoff(time.Second))}
+// 		wr        = writer.New(cli, bucket, org, writer.WithRetries(retryOpts...))
+// 	)
+// }
 package writer

--- a/writer/doc.go
+++ b/writer/doc.go
@@ -61,4 +61,31 @@
 //
 // Finally, it wraps the buffered writer in a *PointsWriter which takes care of ensuring Flush is called
 // automatically when it hasn't been called for a configured duration. This final type is safe for concurrent use.
+//
+// Automatic Retries
+//
+// The write package offers automatic retry capabilities during known transient failure conditions
+// This is when the API being consumed reports "unavailable" or "too many requests" error conditions
+//
+//  import (
+//      "github.com/influxdata/influxdb-client-go"
+//      "github.com/influxdata/influxdb-client-go/writer"
+//  )
+//
+//  func main() {
+//      var (
+//          cli, _ = influxdb.New("http://localhost:9999", "some-token")
+//          bucket = "default"
+//          org    = "influx"
+//      )
+//
+//      // construct a writer with 3 maximum attempts per call to Write and linear backoff derived from number of attempts
+//      // i.e. a first attempt is followed by a 1 second delay before the second attempt
+//      // a second attempt is followed by a 2 second delay before the third attempt
+//      wr := writer.New(cli, bucket, org, writer.WithRetries(writer.MaxAttempts(3), writer.LinearBackoff(time.Second)))
+//
+//      // ...
+//      // attempts to write will automatically retry when influx API reports unavailable or while being
+//      // rate limited.
+//  }
 package writer

--- a/writer/options.go
+++ b/writer/options.go
@@ -6,6 +6,8 @@ import "time"
 type Config struct {
 	size          int
 	flushInterval time.Duration
+	retry         bool
+	retryOptions  []RetryOption
 }
 
 // Option is a functional option for Configuring point writers
@@ -47,5 +49,15 @@ func WithBufferSize(size int) Option {
 func WithFlushInterval(interval time.Duration) Option {
 	return func(c *Config) {
 		c.flushInterval = interval
+	}
+}
+
+// WithRetries configures automatic retry behavior on specific
+// transient error conditions when attempting to Write metrics
+// to a client
+func WithRetries(options ...RetryOption) Option {
+	return func(c *Config) {
+		c.retry = true
+		c.retryOptions = options
 	}
 }

--- a/writer/retry.go
+++ b/writer/retry.go
@@ -63,6 +63,7 @@ func (r *RetryWriter) Write(m ...influxdb.Metric) (n int, err error) {
 				// given retry-after is configured attempt to sleep
 				// for retry-after seconds
 				r.sleep(time.Duration(*ierr.RetryAfter) * time.Second)
+				continue
 			}
 
 			// given a backoff duration > 0

--- a/writer/retry.go
+++ b/writer/retry.go
@@ -15,12 +15,29 @@ type RetryWriter struct {
 
 // NewRetryWriter returns a configured *RetryWriter which decorates
 // the supplied MetricsWriter
-func NewRetryWriter(w MetricsWriter) *RetryWriter {
-	return &RetryWriter{MetricsWriter: w, maxAttempts: defaultMaxAttempts}
+func NewRetryWriter(w MetricsWriter, opts ...RetryOption) *RetryWriter {
+	r := &RetryWriter{MetricsWriter: w, maxAttempts: defaultMaxAttempts}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
 }
 
 // Write delegates to underlying MetricsWriter and then
 // automatically retries when errors occur
 func (r *RetryWriter) Write(m ...influxdb.Metric) (int, error) {
 	return len(m), influxdb.ErrUnimplemented
+}
+
+// RetryOption is a functional option for the RetryWriters type
+type RetryOption func(*RetryWriter)
+
+// WithMaxAttempts sets the maximum number of attempts for a
+// Write operation attempt
+func WithMaxAttempts(maxAttempts int) RetryOption {
+	return func(r *RetryWriter) {
+		r.maxAttempts = maxAttempts
+	}
 }

--- a/writer/retry.go
+++ b/writer/retry.go
@@ -48,12 +48,12 @@ func (r *RetryWriter) Write(m ...influxdb.Metric) (n int, err error) {
 	for i := 0; i < r.maxAttempts; i++ {
 		n, err = r.MetricsWriter.Write(m...)
 		if err == nil {
-			break
+			return
 		}
 
 		ierr, ok := err.(*influxdb.Error)
 		if !ok {
-			break
+			return
 		}
 
 		switch ierr.Code {
@@ -71,7 +71,7 @@ func (r *RetryWriter) Write(m ...influxdb.Metric) (n int, err error) {
 				r.sleep(duration)
 			}
 		default:
-			break
+			return
 		}
 	}
 

--- a/writer/retry.go
+++ b/writer/retry.go
@@ -1,0 +1,26 @@
+package writer
+
+import "github.com/influxdata/influxdb-client-go"
+
+const defaultMaxAttempts = 5
+
+// RetryWriter is a metrics writers which decorates other
+// metrics writer implementations and automatically retries
+// attempts to write metrics under certain error conditions
+type RetryWriter struct {
+	MetricsWriter
+
+	maxAttempts int
+}
+
+// NewRetryWriter returns a configured *RetryWriter which decorates
+// the supplied MetricsWriter
+func NewRetryWriter(w MetricsWriter) *RetryWriter {
+	return &RetryWriter{MetricsWriter: w, maxAttempts: defaultMaxAttempts}
+}
+
+// Write delegates to underlying MetricsWriter and then
+// automatically retries when errors occur
+func (r *RetryWriter) Write(m ...influxdb.Metric) (int, error) {
+	return len(m), influxdb.ErrUnimplemented
+}

--- a/writer/retry_test.go
+++ b/writer/retry_test.go
@@ -18,8 +18,6 @@ var (
 			RetryAfter: retryAfter,
 		}
 	}
-	one   int32 = 1
-	two   int32 = 2
 	three int32 = 3
 )
 
@@ -66,6 +64,20 @@ func Test_RetryWriter_Write(t *testing.T) {
 			writes: [][]influxdb.Metric{
 				// two writes, second succeeds
 				createTestRowMetrics(t, 3),
+				createTestRowMetrics(t, 3),
+			},
+		},
+		{
+			name:    `one "internal error" error (max attempts 3)`,
+			options: []RetryOption{WithMaxAttempts(3)},
+			metrics: createTestRowMetrics(t, 3),
+			errors: []error{
+				&influxdb.Error{Code: influxdb.EInternal, Message: "something went wrong"},
+			},
+			count: 0,
+			err:   &influxdb.Error{Code: influxdb.EInternal, Message: "something went wrong"},
+			writes: [][]influxdb.Metric{
+				// one attempted write
 				createTestRowMetrics(t, 3),
 			},
 		},

--- a/writer/retry_test.go
+++ b/writer/retry_test.go
@@ -92,8 +92,8 @@ func Test_RetryWriter_Write(t *testing.T) {
 			options: []RetryOption{WithMaxAttempts(3)},
 			metrics: createTestRowMetrics(t, 3),
 			errors: []error{
-				errTooMany(&one),
-				errTooMany(&two),
+				errTooMany(&three),
+				errTooMany(&three),
 				errTooMany(&three),
 			},
 			count: 0,
@@ -105,9 +105,35 @@ func Test_RetryWriter_Write(t *testing.T) {
 				createTestRowMetrics(t, 3),
 			},
 			sleeps: []time.Duration{
-				time.Second,
-				2 * time.Second,
 				3 * time.Second,
+				3 * time.Second,
+				3 * time.Second,
+			},
+		},
+		{
+			name: `three "too many requests" errors (max attempts 3) with backoff`,
+			options: []RetryOption{
+				WithMaxAttempts(3),
+				WithBackoff(LinearBackoff(time.Millisecond)),
+			},
+			metrics: createTestRowMetrics(t, 3),
+			errors: []error{
+				errTooMany(nil),
+				errTooMany(nil),
+				errTooMany(nil),
+			},
+			count: 0,
+			err:   errTooMany(nil),
+			writes: [][]influxdb.Metric{
+				// three writes all error
+				createTestRowMetrics(t, 3),
+				createTestRowMetrics(t, 3),
+				createTestRowMetrics(t, 3),
+			},
+			sleeps: []time.Duration{
+				1 * time.Millisecond,
+				2 * time.Millisecond,
+				3 * time.Millisecond,
 			},
 		},
 	} {

--- a/writer/retry_test.go
+++ b/writer/retry_test.go
@@ -1,0 +1,86 @@
+package writer
+
+import (
+	"testing"
+
+	"github.com/influxdata/influxdb-client-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_RetryWriter_Write(t *testing.T) {
+	for _, test := range []retryWriteCase{
+		{
+			name:    `two "too many requests" errors (max attempts 3)`,
+			options: []RetryOption{WithMaxAttempts(3)},
+			metrics: createTestRowMetrics(t, 10),
+			errors: []error{
+				influxdb.Error{Code: influxdb.ETooManyRequests, Message: "too many requests"},
+				influxdb.Error{Code: influxdb.ETooManyRequests, Message: "too many requests"},
+			},
+			count: 10,
+			writes: [][]influxdb.Metric{
+				createTestRowMetrics(t, 10),
+				createTestRowMetrics(t, 10),
+			},
+		},
+		{
+			name:    `two "unavailable" errors (max attempts 3)`,
+			options: []RetryOption{WithMaxAttempts(3)},
+			metrics: createTestRowMetrics(t, 10),
+			errors: []error{
+				influxdb.Error{Code: influxdb.EUnavailable, Message: "too many requests"},
+				influxdb.Error{Code: influxdb.EUnavailable, Message: "too many requests"},
+			},
+			count: 10,
+			writes: [][]influxdb.Metric{
+				createTestRowMetrics(t, 10),
+				createTestRowMetrics(t, 10),
+			},
+		},
+		{
+			name:    `three "too many requests" errors (max attempts 3)`,
+			options: []RetryOption{WithMaxAttempts(3)},
+			metrics: createTestRowMetrics(t, 10),
+			errors: []error{
+				influxdb.Error{Code: influxdb.ETooManyRequests, Message: "too many requests"},
+				influxdb.Error{Code: influxdb.ETooManyRequests, Message: "too many requests"},
+				influxdb.Error{Code: influxdb.ETooManyRequests, Message: "too many requests"},
+			},
+			count: 0,
+			err:   influxdb.Error{Code: influxdb.ETooManyRequests, Message: "too many requests"},
+			writes: [][]influxdb.Metric{
+				createTestRowMetrics(t, 10),
+				createTestRowMetrics(t, 10),
+				createTestRowMetrics(t, 10),
+			},
+		},
+	} {
+		t.Run(test.name, test.Run)
+	}
+}
+
+type retryWriteCase struct {
+	name string
+	// inputs
+	options []RetryOption
+	metrics []influxdb.Metric
+	// errors returned by write
+	errors []error
+	// response expectations
+	count int
+	err   error
+	// attempted writes
+	writes [][]influxdb.Metric
+}
+
+func (test *retryWriteCase) Run(t *testing.T) {
+	var (
+		writer     = newTestWriter()
+		retry      = NewRetryWriter(writer, test.options...)
+		count, err = retry.Write(test.metrics...)
+	)
+
+	assert.Equal(t, test.err, err)
+	assert.Equal(t, test.count, count)
+	assert.Equal(t, test.writes, writer.writes)
+}

--- a/writer/support_test.go
+++ b/writer/support_test.go
@@ -36,8 +36,8 @@ type metricsWriter struct {
 	errs   []error
 }
 
-func newTestWriter() *metricsWriter {
-	return &metricsWriter{n: -1}
+func newTestWriter(errs ...error) *metricsWriter {
+	return &metricsWriter{n: -1, errs: errs}
 }
 
 func (w *metricsWriter) Write(m ...influxdb.Metric) (n int, err error) {
@@ -48,10 +48,12 @@ func (w *metricsWriter) Write(m ...influxdb.Metric) (n int, err error) {
 
 	n = len(m)
 	if w.n > -1 {
+		// override length response
 		n = w.n
 	}
 
 	if w.called < len(w.errs) {
+		n = 0
 		err = w.errs[w.called]
 	}
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -22,6 +22,12 @@ func New(writer BucketMetricWriter, bkt, org string, opts ...Option) *PointWrite
 		buffered = NewBufferedWriterSize(bucket, config.size)
 	)
 
+	if config.retry {
+		// configure automatic retries for transient errors
+		retry := NewRetryWriter(bucket, config.retryOptions...)
+		buffered = NewBufferedWriterSize(retry, config.size)
+	}
+
 	return NewPointWriter(buffered, config.flushInterval)
 }
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -13,7 +13,7 @@ func Test_New(t *testing.T) {
 		client  = &influxdb.Client{}
 		bkt     = "default"
 		org     = "influx"
-		options = Options{WithBufferSize(12), WithFlushInterval(5 * time.Minute)}
+		options = Options{WithBufferSize(12), WithFlushInterval(5 * time.Minute), WithRetries()}
 		wr      = New(client, bkt, org, options...)
 	)
 


### PR DESCRIPTION
closes #46

This reinstates the ability to automatically retry writes based on known transient error conditions.

See updates to docs.go:
```go
import (
	"time"

	"github.com/influxdata/influxdb-client-go"
	"github.com/influxdata/influxdb-client-go/writer"
)

func main() {
	var (
		cli, _ = influxdb.New("http://localhost:9999", "some-token")
		bucket = "default"
		org    = "influx"
	)

	// construct a writer with 3 maximum attempts per call to Write and linear backoff derived from number of attempts
	// i.e. a first attempt is followed by a 1 second delay before the second attempt
	// a second attempt is followed by a 2 second delay before the third attempt
	var (
		retryOpts = []writer.RetryOption{writer.WithMaxAttempts(3), writer.WithBackoff(writer.LinearBackoff(time.Second))}
		wr        = writer.New(cli, bucket, org, writer.WithRetries(retryOpts...))
	)
}
```

Namely:
- unavailable
- too many requests (rate limiting)

TODO:

- [x] implement basic retry behavior with max attempts
- [x] implement backoff which respects Retry-After response header
- [x] implement backoff which is configured via a backoff function
- [x] configure and wire retry writer into `writer.New()` response type
- [x] more tests around `write.go` handling of error parsing