### PR TITLE
Reorder arguments bucket and org in bucket writer

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -9,7 +9,7 @@ import (
 // BucketMetricWriter is a type which Metrics can be written to a particular bucket
 // in a particular organisation
 type BucketMetricWriter interface {
-	Write(context.Context, string, string, ...influxdb.Metric) (int, error)
+	Write(ctx context.Context, bucket string, org string, m ...influxdb.Metric) (int, error)
 }
 
 // New constructs a point writer with an underlying buffer from the provided BucketMetricWriter
@@ -51,5 +51,5 @@ func NewBucketWriter(w BucketMetricWriter, bucket, org string) *BucketWriter {
 // Write writes the provided metrics to the underlying metrics writer
 // using the org and bucket configured on the bucket writer
 func (b *BucketWriter) Write(m ...influxdb.Metric) (int, error) {
-	return b.w.Write(b.ctxt, b.org, b.bucket, m...)
+	return b.w.Write(b.ctxt, b.bucket, b.org, m...)
 }

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -31,10 +31,10 @@ func Test_BucketWriter(t *testing.T) {
 		wr     = NewBucketWriter(spy, bucket, org)
 
 		expected = []bucketWriteCall{
-			{org, bucket, createTestRowMetrics(t, 4)},
-			{org, bucket, createTestRowMetrics(t, 8)},
-			{org, bucket, createTestRowMetrics(t, 12)},
-			{org, bucket, createTestRowMetrics(t, 16)},
+			{bucket, org, createTestRowMetrics(t, 4)},
+			{bucket, org, createTestRowMetrics(t, 8)},
+			{bucket, org, createTestRowMetrics(t, 12)},
+			{bucket, org, createTestRowMetrics(t, 16)},
 		}
 	)
 


### PR DESCRIPTION
The order of the bucket and organization arguments is incorrect. The client takes a bucket before the org. Sadly my test was ensuring it was the wrong way around.

This reorders the arguments correctly.