### PR TITLE
Add WithContext config option to writers package

### DIFF
--- a/writer/options.go
+++ b/writer/options.go
@@ -1,9 +1,13 @@
 package writer
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Config is a structure used to configure a point writer
 type Config struct {
+	ctxt          context.Context
 	size          int
 	flushInterval time.Duration
 	retry         bool
@@ -20,6 +24,7 @@ type Options []Option
 // applies the callee options and returns the config
 func (o Options) Config() Config {
 	config := Config{
+		ctxt:          context.Background(),
 		size:          defaultBufferSize,
 		flushInterval: defaultFlushInterval,
 	}
@@ -33,6 +38,13 @@ func (o Options) Config() Config {
 func (o Options) Apply(c *Config) {
 	for _, opt := range o {
 		opt(c)
+	}
+}
+
+// WithContext sets the context.Context used for each flush
+func WithContext(ctxt context.Context) Option {
+	return func(c *Config) {
+		c.ctxt = ctxt
 	}
 }
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -22,6 +22,9 @@ func New(writer BucketMetricWriter, bkt, org string, opts ...Option) *PointWrite
 		buffered = NewBufferedWriterSize(bucket, config.size)
 	)
 
+	// set bucket write context to provided context
+	bucket.ctxt = config.ctxt
+
 	if config.retry {
 		// configure automatic retries for transient errors
 		retry := NewRetryWriter(bucket, config.retryOptions...)


### PR DESCRIPTION
This allows the threading of a `context.Context` to be made for all batches written to a `writer.PointWriter` constructed with `New(...)`

Each time `BufferedWriter.Flush` is called this `context.Context` will be used in the call to `client.Write(ctx, ...)`.