### PR TITLE
Ensure UintSupport enabled in line-protocol encoder on write

### DIFF
--- a/write.go
+++ b/write.go
@@ -26,6 +26,7 @@ func (c *Client) Write(ctx context.Context, bucket, org string, m ...Metric) (n 
 		e   = lp.NewEncoder(buf)
 	)
 
+	e.SetFieldTypeSupport(lp.UintSupport)
 	e.FailOnFieldErr(c.errOnFieldErr)
 
 	select {


### PR DESCRIPTION
I recently learned `UintSupport` is required for 2.x and not supported in 1.x.
This is causing some bugs when writing uint64 values with this client.

This change enabled `UintSupport` in the line protocol encoder used in client writes.