### PR TITLE
feat: Retry writer should split too-big payloads

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	influxdb "github.com/influxdata/influxdb-client-go"
+	"github.com/influxdata/influxdb-client-go"
 )
 
 var e2e bool
@@ -17,7 +17,6 @@ var fuzz bool
 func init() {
 	flag.BoolVar(&e2e, "e2e", false, "run the end tests (requires a working influxdb instance on 127.0.0.1)")
 	flag.BoolVar(&fuzz, "fuzz", false, "(Not Implemented) run the end tests (requires a working influxdb instance on 127.0.0.1)")
-	flag.Parse()
 }
 
 func TestE2E(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -18,6 +18,7 @@ const (
 	ETooManyRequests     = "too many requests"
 	EUnauthorized        = "unauthorized"
 	EMethodNotAllowed    = "method not allowed"
+	ETooLarge            = "request too large"
 )
 
 // ErrUnimplemented is an error for when pieces of the client's functionality is unimplemented.
@@ -27,6 +28,7 @@ var ErrUnimplemented = errors.New("unimplemented")
 // It contains a number of contextual fields which describe the nature
 // and cause of the error
 type Error struct {
+	StatusCode int
 	Code       string
 	Message    string
 	Err        string

--- a/write_test.go
+++ b/write_test.go
@@ -75,6 +75,7 @@ some_measurement,some_tag=some_value some_int=2i,some_uint=2u 154630080000000000
 				"Retry-After": []string{"5"},
 			},
 			err: &Error{
+				StatusCode: 429,
 				Code:       ETooManyRequests,
 				Message:    "exceeded rate limit",
 				RetryAfter: &five,
@@ -86,8 +87,9 @@ some_measurement,some_tag=some_value some_int=2i,some_uint=2u 154630080000000000
 			statusCode: http.StatusServiceUnavailable,
 			headers:    http.Header{},
 			err: &Error{
-				Code:    EUnavailable,
-				Message: "service temporarily unavailable",
+				StatusCode: 503,
+				Code:       EUnavailable,
+				Message:    "service temporarily unavailable",
 			},
 		},
 		{
@@ -99,9 +101,10 @@ some_measurement,some_tag=some_value some_int=2i,some_uint=2u 154630080000000000
 				"Content-Type": []string{"application/json; charset=utf-8"},
 			},
 			err: &Error{
-				Code:    EInternal,
-				Op:      "doing something",
-				Message: "foo",
+				StatusCode: 500,
+				Code:       EInternal,
+				Op:         "doing something",
+				Message:    "foo",
 			},
 		},
 		{
@@ -110,8 +113,20 @@ some_measurement,some_tag=some_value some_int=2i,some_uint=2u 154630080000000000
 			statusCode: http.StatusBadRequest,
 			body:       []byte(`payload is bad`),
 			err: &Error{
-				Code:    "400 Bad Request",
-				Message: "payload is bad",
+				StatusCode: 400,
+				Code:       "400 Bad Request",
+				Message:    "payload is bad",
+			},
+		},
+		{
+			name:       "size limited",
+			metrics:    createTestRowMetrics(t, 10),
+			statusCode: http.StatusRequestEntityTooLarge,
+			headers:    http.Header{},
+			err: &Error{
+				StatusCode: 413,
+				Code:       ETooLarge,
+				Message:    "tried to write too large a batch",
 			},
 		},
 	} {

--- a/writer/options.go
+++ b/writer/options.go
@@ -27,6 +27,8 @@ func (o Options) Config() Config {
 		ctxt:          context.Background(),
 		size:          defaultBufferSize,
 		flushInterval: defaultFlushInterval,
+		retry:         true,
+		retryOptions:  []RetryOption{},
 	}
 
 	o.Apply(&config)

--- a/writer/retry.go
+++ b/writer/retry.go
@@ -3,7 +3,7 @@ package writer
 import (
 	"time"
 
-	"github.com/influxdata/influxdb-client-go"
+	influxdb "github.com/influxdata/influxdb-client-go"
 )
 
 const defaultMaxAttempts = 5
@@ -43,7 +43,8 @@ func NewRetryWriter(w MetricsWriter, opts ...RetryOption) *RetryWriter {
 }
 
 // Write delegates to underlying MetricsWriter and then
-// automatically retries when errors occur
+// automatically retries when certain errors occur.
+// note: this does not pass/fail atomically, and may return a short write.
 func (r *RetryWriter) Write(m ...influxdb.Metric) (n int, err error) {
 	for i := 0; i < r.maxAttempts; i++ {
 		n, err = r.MetricsWriter.Write(m...)
@@ -71,11 +72,23 @@ func (r *RetryWriter) Write(m ...influxdb.Metric) (n int, err error) {
 				// call sleep with backoff duration
 				r.sleep(duration)
 			}
+		case influxdb.ETooLarge:
+			// given retry-after is configured attempt to sleep
+			// for retry-after seconds
+			if ierr.RetryAfter != nil {
+				r.sleep(time.Duration(*ierr.RetryAfter) * time.Second)
+			}
+			n0, err := r.Write(m[:(len(m) / 2)]...)
+			if err != nil {
+				return n0, err
+			}
+			n1, err := r.Write(m[(len(m) / 2):]...)
+			return n0 + n1, err
+
 		default:
 			return
 		}
 	}
-
 	return
 }
 

--- a/writer/support_test.go
+++ b/writer/support_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/influxdb-client-go"
+	influxdb "github.com/influxdata/influxdb-client-go"
 )
 
 type bucketWriter struct {
@@ -53,8 +53,13 @@ func (w *metricsWriter) Write(m ...influxdb.Metric) (n int, err error) {
 	}
 
 	if w.called < len(w.errs) {
-		n = 0
 		err = w.errs[w.called]
+		// the next bit is so we can do errors that happen out of order or after a success in the test\
+		if err == error(nil) {
+			err = nil
+		} else {
+			n = 0
+		}
 	}
 
 	return


### PR DESCRIPTION
This changes the retry writer to split excessively large payloads when
the influxdb returns an http.StatusRequestEntityTooLarge response.

Closes: https://github.com/influxdata/influxdb-client-go/issues/72