### PR TITLE
extract WriteBuffer from Write to allow writing raw line protocol

### DIFF
--- a/write.go
+++ b/write.go
@@ -40,6 +40,20 @@ func (c *Client) Write(ctx context.Context, bucket, org string, m ...Metric) (n 
 		}
 	}
 
+	_, err = c.WriteBuffer(ctx, bucket, org, buf)
+	if err == nil {
+		n = len(m)
+	}
+	return n, err
+}
+
+func (c *Client) WriteBuffer(ctx context.Context, bucket, org string, buf *bytes.Buffer) (n int64, err error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+
 	var req *http.Request
 
 	if c.contentEncoding == "gzip" {
@@ -71,7 +85,7 @@ func (c *Client) Write(ctx context.Context, bucket, org string, m ...Metric) (n 
 		return 0, eerr
 	}
 
-	return len(m), nil
+	return req.ContentLength, nil
 }
 
 func parseInt32(v string) (int32, error) {


### PR DESCRIPTION
I have raw line protocol that I'd like to forward through to influx via
the client.

I don't want to parse it into `Metric`'s only to encode it back to bytes.

I could implement my own client in raw net/http, but I'd like to be able
to use some of the official client's config & careful connection
handling.