### PR TITLE
Expose CSV column properties

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/influxdata/influxdb-client-go
 
-go 1.14
-
 require (
 	github.com/google/go-cmp v0.2.0 // test dependency
 	github.com/influxdata/flux v0.0.0-20190620184636-886e3c28388d // test dependency

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/influxdata/influxdb-client-go
 
+go 1.14
+
 require (
 	github.com/google/go-cmp v0.2.0 // test dependency
 	github.com/influxdata/flux v0.0.0-20190620184636-886e3c28388d // test dependency

--- a/query_test.go
+++ b/query_test.go
@@ -113,9 +113,9 @@ func TestQueryCSVResult_Unmarshal(t *testing.T) {
 				csvReader:   csv.NewReader(ioutil.NopCloser(buf)),
 				Row:         tt.fields.Row,
 				ColNames:    tt.fields.ColNames,
-				dataTypes:   tt.fields.dataTypes,
-				group:       tt.fields.group,
-				defaultVals: tt.fields.defaultVals,
+				DataTypes:   tt.fields.dataTypes,
+				Group:       tt.fields.group,
+				DefaultVals: tt.fields.defaultVals,
 				Err:         tt.fields.Err,
 			}
 			q.Next()
@@ -227,11 +227,7 @@ func TestQueryMultipleYields(t *testing.T) {
 		},
 	}
 
-	q := &QueryCSVResult{
-		ReadCloser: ioutil.NopCloser(buf),
-	}
-	q.csvReader = csv.NewReader(q.ReadCloser)
-	q.csvReader.FieldsPerRecord = -1
+	q := QueryCSVResultFromBytes(buf)
 	line := 0
 	for q.Next() {
 		m := make(map[string]interface{})


### PR DESCRIPTION
I am working on a grafana plugin that will read CSV results from influx and convert the results to an arrow table.

The QueryCSVResult is almost perfect... except that I need access to the private properties.  This PR:
* makes DataType, Group, DefaultVals public
* adds a helper function to create QueryCSVResult from a byte buffer.  This is helpful for testing.
