### PR TITLE
Additional documentation on WriteApi.Errors()

### DIFF
--- a/write.go
+++ b/write.go
@@ -25,7 +25,9 @@ type WriteApi interface {
 	Flush()
 	// Flushes all pending writes and stop async processes. After this the Write client cannot be used
 	Close()
-	// Errors return channel for reading errors which occurs during async writes
+	// Errors returns a channel for reading errors which occurs during async writes.
+	// Must be called before performing any writes for errors to be collected.
+	// The chan is unbuffered and must be drained or the writer will block.
 	Errors() <-chan error
 }
 


### PR DESCRIPTION
This extends the documentation on this method to clarify a couple of major caveats that users need to be aware of.

- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)