### PR TITLE
refactor: Renaming InfluxDBClient -> Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+## Breaking Change
+ - [#107](https://github.com/influxdata/influxdb-client-go/pull/100) Renamed `InfluxDBClient` interface to `Client`, so the full name `influxdb2.Client` suits better to Go naming conventions
+ 
 ## 1.1.0 [2020-04-24]
 ### Features
 1. [#100](https://github.com/influxdata/influxdb-client-go/pull/100)  HTTP request timeout made configurable

--- a/query.go
+++ b/query.go
@@ -47,7 +47,7 @@ type QueryApi interface {
 	Query(ctx context.Context, query string) (*QueryTableResult, error)
 }
 
-func newQueryApi(org string, service ihttp.Service, client InfluxDBClient) QueryApi {
+func newQueryApi(org string, service ihttp.Service, client Client) QueryApi {
 	return &queryApiImpl{
 		org:         org,
 		httpService: service,
@@ -59,7 +59,7 @@ func newQueryApi(org string, service ihttp.Service, client InfluxDBClient) Query
 type queryApiImpl struct {
 	org         string
 	httpService ihttp.Service
-	client      InfluxDBClient
+	client      Client
 	url         string
 	lock        sync.Mutex
 }

--- a/write.go
+++ b/write.go
@@ -48,7 +48,7 @@ type writeBuffInfoReq struct {
 	writeBuffLen int
 }
 
-func newWriteApiImpl(org string, bucket string, service http.Service, client InfluxDBClient) *writeApiImpl {
+func newWriteApiImpl(org string, bucket string, service http.Service, client Client) *writeApiImpl {
 	w := &writeApiImpl{
 		service:      newWriteService(org, bucket, service, client),
 		writeBuffer:  make([]string, 0, client.Options().BatchSize()+1),
@@ -137,7 +137,7 @@ func (w *writeApiImpl) flushBuffer() {
 		w.writeCh <- batch
 		//	lines = lines[:0]
 		//}(w.writeBuffer)
-		//w.writeBuffer = make([]string,0, w.service.client.Options.BatchSize+1)
+		//w.writeBuffer = make([]string,0, w.service.clientImpl.Options.BatchSize+1)
 		w.writeBuffer = w.writeBuffer[:0]
 	}
 }
@@ -201,7 +201,7 @@ func (w *writeApiImpl) WriteRecord(line string) {
 }
 
 func (w *writeApiImpl) WritePoint(point *Point) {
-	//w.bufferCh <- point.ToLineProtocol(w.service.client.Options().Precision)
+	//w.bufferCh <- point.ToLineProtocol(w.service.clientImpl.Options().Precision)
 	line, err := w.service.encodePoints(point)
 	if err != nil {
 		logger.Errorf("point encoding error: %s\n", err.Error())

--- a/writeApiBlocking.go
+++ b/writeApiBlocking.go
@@ -28,7 +28,7 @@ type writeApiBlockingImpl struct {
 }
 
 // creates writeApiBlockingImpl for org and bucket with underlying client
-func newWriteApiBlockingImpl(org string, bucket string, service http.Service, client InfluxDBClient) *writeApiBlockingImpl {
+func newWriteApiBlockingImpl(org string, bucket string, service http.Service, client Client) *writeApiBlockingImpl {
 	return &writeApiBlockingImpl{service: newWriteService(org, bucket, service, client)}
 }
 

--- a/writeService.go
+++ b/writeService.go
@@ -36,10 +36,10 @@ type writeService struct {
 	lastWriteAttempt time.Time
 	retryQueue       *queue
 	lock             sync.Mutex
-	client           InfluxDBClient
+	client           Client
 }
 
-func newWriteService(org string, bucket string, httpService ihttp.Service, client InfluxDBClient) *writeService {
+func newWriteService(org string, bucket string, httpService ihttp.Service, client Client) *writeService {
 	logger.SetDebugLevel(client.Options().LogLevel())
 	retryBufferLimit := client.Options().RetryBufferLimit() / client.Options().BatchSize()
 	if retryBufferLimit == 0 {

--- a/write_test.go
+++ b/write_test.go
@@ -62,13 +62,13 @@ func (t *testHttpService) ReplyError() *ihttp.Error {
 	return t.replyError
 }
 
-func (t *testHttpService) SetAuthorization(authorization string) {
+func (t *testHttpService) SetAuthorization(_ string) {
 
 }
 func (t *testHttpService) GetRequest(_ context.Context, _ string, _ ihttp.RequestCallback, _ ihttp.ResponseCallback) *ihttp.Error {
 	return nil
 }
-func (t *testHttpService) DoHttpRequest(req *http.Request, requestCallback ihttp.RequestCallback, _ ihttp.ResponseCallback) *ihttp.Error {
+func (t *testHttpService) DoHttpRequest(_ *http.Request, _ ihttp.RequestCallback, _ ihttp.ResponseCallback) *ihttp.Error {
 	return nil
 }
 
@@ -121,11 +121,11 @@ func (t *testHttpService) Lines() []string {
 	return t.lines
 }
 
-func newTestClient() *client {
-	return &client{serverUrl: "http://locahost:4444", options: DefaultOptions()}
+func newTestClient() *clientImpl {
+	return &clientImpl{serverUrl: "http://locahost:4444", options: DefaultOptions()}
 }
 
-func newTestService(t *testing.T, client InfluxDBClient) *testHttpService {
+func newTestService(t *testing.T, client Client) *testHttpService {
 	return &testHttpService{
 		t:         t,
 		options:   client.Options(),


### PR DESCRIPTION
Renamed `InfluxDBClient` interface to `Client`, so the full name `influxdb2.Client` suits better to Go naming conventions

Closes #103 

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass