### PR TITLE
fix: Handling empty values 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 1.2.0
 ## Breaking Change
  - [#107](https://github.com/influxdata/influxdb-client-go/pull/100) Renamed `InfluxDBClient` interface to `Client`, so the full name `influxdb2.Client` suits better to Go naming conventions
- 
+
+## Bug fixes 
+1. [#110](https://github.com/influxdata/influxdb-client-go/issues/110) Allowing empty (nil) values
+
 ## 1.1.0 [2020-04-24]
 ### Features
 1. [#100](https://github.com/influxdata/influxdb-client-go/pull/100)  HTTP request timeout made configurable

--- a/query.go
+++ b/query.go
@@ -346,6 +346,9 @@ func stringTernary(a, b string) string {
 
 // toValues converts s into type by t
 func toValue(s, t, name string) (interface{}, error) {
+	if s == "" {
+		return nil, nil
+	}
 	switch t {
 	case stringDatatype:
 		return s, nil

--- a/table.go
+++ b/table.go
@@ -155,7 +155,7 @@ func (r *FluxRecord) Time() time.Time {
 	return r.ValueByKey("_time").(time.Time)
 }
 
-// Value returns the actual field value
+// Value returns the default _value column value or nil if not present
 func (r *FluxRecord) Value() interface{} {
 	return r.ValueByKey("_value")
 }
@@ -175,7 +175,7 @@ func (r *FluxRecord) Values() map[string]interface{} {
 	return r.values
 }
 
-// ValueByKey returns value for given column key for the record
+// ValueByKey returns value for given column key for the record or nil of result has no value the column key
 func (r *FluxRecord) ValueByKey(key string) interface{} {
 	return r.values[key]
 }


### PR DESCRIPTION
Closes #110

Added handling of empty (nil) values in the flux result set

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)