### PR TITLE
fix: Fixing comment for retry interval (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
  - [#107](https://github.com/influxdata/influxdb-client-go/pull/100) Renamed `InfluxDBClient` interface to `Client`, so the full name `influxdb2.Client` suits better to Go naming conventions
 
 ### Bug fixes 
+1. [#108](https://github.com/influxdata/influxdb-client-go/issues/108) Fix default retry interval doc
 1. [#110](https://github.com/influxdata/influxdb-client-go/issues/110) Allowing empty (nil) values
+
 
 ### Documentation
  - [#112](https://github.com/influxdata/influxdb-client-go/pull/112) Clarify how to use client with InfluxDB 1.8+

--- a/options.go
+++ b/options.go
@@ -15,7 +15,7 @@ type Options struct {
 	batchSize uint
 	// Interval, in ms, in which is buffer flushed if it has not been already written (by reaching batch size) . Default 1000ms
 	flushInterval uint
-	// Default retry interval in ms, if not sent by server. Default 30s
+	// Default retry interval in ms, if not sent by server. Default 1000ms
 	retryInterval uint
 	// Maximum count of retry attempts of failed writes
 	maxRetries uint
@@ -56,7 +56,7 @@ func (o *Options) SetFlushInterval(flushIntervalMs uint) *Options {
 	return o
 }
 
-// RetryInterval returns retry interval in ms
+// RetryInterval returns the retry interval in ms
 func (o *Options) RetryInterval() uint {
 	return o.retryInterval
 }


### PR DESCRIPTION
Closes #108

Fixing default retry interval value in the comment for the retry interval

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
