### PR TITLE
docs: Doc and examples for WriteApi.Errors()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 1. [#108](https://github.com/influxdata/influxdb-client-go/issues/108) Fix default retry interval doc
 1. [#110](https://github.com/influxdata/influxdb-client-go/issues/110) Allowing empty (nil) values
 
-
 ### Documentation
  - [#112](https://github.com/influxdata/influxdb-client-go/pull/112) Clarify how to use client with InfluxDB 1.8+
+ - [#115](https://github.com/influxdata/influxdb-client-go/pull/115) Doc and examples for reading write api errors 
 
 ## 1.1.0 [2020-04-24]
 ### Features

--- a/README.md
+++ b/README.md
@@ -181,6 +181,58 @@ func main() {
     client.Close()
 }
 ```
+
+### Reading async errors
+[Error()](https://github.com/influxdata/influxdb-client-go/blob/master/write.go#L24) method returns a channel for reading errors which occurs during async writes. This channel is unbuffered and it 
+must be read asynchronously otherwise will block write procedure:
+
+```go
+package main
+
+import (
+    "fmt"
+    "math/rand"
+    "time"
+
+    "github.com/influxdata/influxdb-client-go"
+)
+
+func main() {
+    // Create client
+    client := influxdb2.NewClient("http://localhost:9999", "my-token")
+    // Get non-blocking write client
+    writeApi := client.WriteApi("my-org", "my-bucket")
+    // Get errors channel
+    errorsCh := writeApi.Errors()
+    // Create go proc for reading and logging errors
+    go func() {
+        for err := range errorsCh {
+            fmt.Printf("write error: %s\n", err.Error())
+        }
+    }()
+    // write some points
+    for i := 0; i < 100; i++ {
+        // create point
+        p := influxdb2.NewPointWithMeasurement("stat").
+            AddTag("id", fmt.Sprintf("rack_%v", i%10)).
+            AddTag("vendor", "AWS").
+            AddTag("hostname", fmt.Sprintf("host_%v", i%100)).
+            AddField("temperature", rand.Float64()*80.0).
+            AddField("disk_free", rand.Float64()*1000.0).
+            AddField("disk_total", (i/10+1)*1000000).
+            AddField("mem_total", (i/100+1)*10000000).
+            AddField("mem_free", rand.Uint64()).
+            SetTime(time.Now())
+        // write asynchronously
+        writeApi.WritePoint(p)
+    }
+    // Force all unwritten data to be sent
+    writeApi.Flush()
+    // Ensures background processes finishes
+    client.Close()
+}
+```
+
 ### Blocking write client 
 Blocking write client writes given point(s) synchronously. It doesn't have implicit batching. Batch is created from given set of points.
 


### PR DESCRIPTION
Closes #102 

Added docs and examples for WriteApi.Errors usage into the Readme and API docs

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)