### PR TITLE
fix: panic in case of unsupported type for write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Features
 1. [#131](https://github.com/influxdata/influxdb-client-go/pull/131) Labels API
 
+### Bug fixes 
+1. [#132](https://github.com/influxdata/influxdb-client-go/pull/132) Properly handle errors instead of panics
+
 ## 1.2.0 [2020-05-15]
 ### Breaking Changes
  - [#107](https://github.com/influxdata/influxdb-client-go/pull/107) Renamed `InfluxDBClient` interface to `Client`, so the full name `influxdb2.Client` suits better to Go naming conventions

--- a/api/write/point.go
+++ b/api/write/point.go
@@ -5,6 +5,7 @@
 package write
 
 import (
+	"fmt"
 	"sort"
 	"time"
 
@@ -155,6 +156,6 @@ func convertField(v interface{}) interface{} {
 	case time.Duration:
 		return v.String()
 	default:
-		panic("unsupported type")
+		return fmt.Sprintf("%v", v)
 	}
 }


### PR DESCRIPTION
Closes #129

Instead of panic, panic in case of an unsupported type passed as a field value when creating new Point, converting it into a string value.

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
