### PR TITLE
fix: allow reordering of annotations in flux query result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes 
 1. [#132](https://github.com/influxdata/influxdb-client-go/pull/132) Properly handle errors instead of panics
+1. [#134](https://github.com/influxdata/influxdb-client-go/pull/134) FluxQueryResult: support reordering of annotations
 
 ## 1.2.0 [2020-05-15]
 ### Breaking Changes

--- a/api/query/table.go
+++ b/api/query/table.go
@@ -80,9 +80,9 @@ func (f *FluxTableMetadata) String() string {
 	return buffer.String()
 }
 
-// newFluxColumn creates FluxColumn for position and data type
-func NewFluxColumn(index int, dataType string) *FluxColumn {
-	return &FluxColumn{index: index, dataType: dataType}
+// newFluxColumn creates FluxColumn for position
+func NewFluxColumn(index int) *FluxColumn {
+	return &FluxColumn{index: index}
 }
 
 // newFluxColumn creates FluxColumn


### PR DESCRIPTION
Closes #133, fixes problem in #110 and #123

Allowing reordering of annotations in a flux query result.

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
