### PR TITLE
fix: errors from InfluxDB 1.8 being empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Features
 1. [#131](https://github.com/influxdata/influxdb-client-go/pull/131) Labels API
 1. [#136](https://github.com/influxdata/influxdb-client-go/pull/136) Possibility to specify default tags
+1. [#138](https://github.com/influxdata/influxdb-client-go/pull/138) Fix errors from InfluxDB 1.8 being empty
 
 ### Bug fixes 
 1. [#132](https://github.com/influxdata/influxdb-client-go/pull/132) Handle unsupported write type as string instead of generating panic

--- a/internal/http/error.go
+++ b/internal/http/error.go
@@ -4,7 +4,10 @@
 
 package http
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 // Error represent error response from InfluxDBServer or http error
 type Error struct {
@@ -17,10 +20,14 @@ type Error struct {
 
 // Error fulfils error interface
 func (e *Error) Error() string {
-	if e.Err != nil {
+	switch {
+	case e.Err != nil:
 		return e.Err.Error()
+	case e.Code != "" && e.Message != "":
+		return fmt.Sprintf("%s: %s", e.Code, e.Message)
+	default:
+		return "Unexpected status code " + strconv.Itoa(e.StatusCode)
 	}
-	return fmt.Sprintf("%s: %s", e.Code, e.Message)
 }
 
 // NewError returns newly created Error initialised with nested error and default values


### PR DESCRIPTION
This PR fixes errors from InfluxDB 1.8 being empty. It does this by falling back to reading the `X-Influxdb-Error`, and if that doesn't work, then `http.Error` would return the unexpected status code inside the error message.

Before PR:

![before PR screenshot](https://media.discordapp.net/attachments/287739410286379019/725485313694236682/unknown.png)

After PR:

![after PR screenshot](https://media.discordapp.net/attachments/287739410286379019/725498363772141588/unknown.png)

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)