### PR TITLE
fix: serialization of `\n`, `\r` and `\t` to Line Protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.0 [unreleased]
+
+### Bug fixes 
+1. [#139](https://github.com/influxdata/influxdb-client-go/pull/139) Fixed serialization of `\n`, `\r` and `\t` to Line Protocol 
+
 ## 1.3.0 [2020-06-19]
 ### Features
 1. [#131](https://github.com/influxdata/influxdb-client-go/pull/131) Labels API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 1.4.0 [unreleased]
-
-### Bug fixes 
-1. [#139](https://github.com/influxdata/influxdb-client-go/pull/139) Fixed serialization of `\n`, `\r` and `\t` to Line Protocol 
-
 ## 1.3.0 [2020-06-19]
 ### Features
 1. [#131](https://github.com/influxdata/influxdb-client-go/pull/131) Labels API

--- a/api/write/ext.go
+++ b/api/write/ext.go
@@ -75,6 +75,15 @@ func PointToLineProtocol(p *Point, precision time.Duration) string {
 func escapeKey(sb *strings.Builder, key string) {
 	for _, r := range key {
 		switch r {
+		case '\n':
+			sb.WriteString(`\\n`)
+			continue
+		case '\r':
+			sb.WriteString(`\\r`)
+			continue
+		case '\t':
+			sb.WriteString(`\\t`)
+			continue
 		case ' ', ',', '=':
 			sb.WriteString(`\`)
 		}

--- a/api/write/point_test.go
+++ b/api/write/point_test.go
@@ -261,6 +261,17 @@ func TestPrecision(t *testing.T) {
 	assert.Equal(t, line, "test,id=10 float64=80.1234567 60\n")
 }
 
+func TestTagEscapingKeyAndValue(t *testing.T) {
+	p := NewPointWithMeasurement("h\n2\no\t_data")
+	p.AddTag("new\nline", "new\nline")
+	p.AddTag("carriage\rreturn", "carriage\rreturn")
+	p.AddTag("t\tab", "t\tab")
+	p.AddField("level", 2)
+
+	line := PointToLineProtocol(p, time.Nanosecond)
+	assert.Equal(t, "h\\\\n2\\\\no\\\\t_data,new\\\\nline=new\\\\nline,carriage\\\\rreturn=carriage\\\\rreturn,t\\\\tab=t\\\\tab level=2i\n", line)
+}
+
 var s string
 
 func BenchmarkPointEncoderSingle(b *testing.B) {


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-java/issues/127

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)