### PR TITLE
chore: Adjusting Label API tests after fixes

### DIFF
--- a/client_e2e_test.go
+++ b/client_e2e_test.go
@@ -782,8 +782,7 @@ func TestLabels(t *testing.T) {
 	labels, err = orgApi.GetLabels(ctx, myorg)
 	require.Nil(t, err, err)
 	require.NotNil(t, labels)
-	// Newly created labels is automatically added. It was 0 before beta 13
-	assert.Len(t, *labels, 1)
+	assert.Len(t, *labels, 0)
 
 	org, err := orgApi.CreateOrganizationWithName(ctx, "org1")
 	require.Nil(t, err, err)
@@ -792,26 +791,24 @@ func TestLabels(t *testing.T) {
 	labels, err = orgApi.GetLabels(ctx, org)
 	require.Nil(t, err, err)
 	require.NotNil(t, labels)
-	// Newly created organization has existing label added. It was 0 before beta 13
+	assert.Len(t, *labels, 0)
+
+	labelx, err := orgApi.AddLabel(ctx, org, label)
+	require.Nil(t, err, err)
+	require.NotNil(t, labelx)
+
+	labels, err = orgApi.GetLabels(ctx, org)
+	require.Nil(t, err, err)
+	require.NotNil(t, labels)
 	assert.Len(t, *labels, 1)
 
-	// Commented due to https://github.com/influxdata/influxdb/issues/18563
-	//labelx, err := orgApi.AddLabel(ctx, org, label)
-	//require.Nil(t, err, err)
-	//require.NotNil(t, labelx)
-	//
-	//labels, err = orgApi.GetLabels(ctx, org)
-	//require.Nil(t, err, err)
-	//require.NotNil(t, labels)
-	//assert.Len(t, *labels, 1)
-	//
-	//err = orgApi.RemoveLabel(ctx, org, label)
-	//require.Nil(t, err, err)
-	//
-	//labels, err = orgApi.GetLabels(ctx, org)
-	//require.Nil(t, err, err)
-	//require.NotNil(t, labels)
-	//assert.Len(t, *labels, 0)
+	err = orgApi.RemoveLabel(ctx, org, label)
+	require.Nil(t, err, err)
+
+	labels, err = orgApi.GetLabels(ctx, org)
+	require.Nil(t, err, err)
+	require.NotNil(t, labels)
+	assert.Len(t, *labels, 0)
 
 	labels, err = orgApi.GetLabelsWithId(ctx, "000000000000000")
 	require.NotNil(t, err, err)


### PR DESCRIPTION
Beta 13 introduced issues [#18773](https://github.com/influxdata/influxdb/issues/18773) and [#18653](https://github.com/influxdata/influxdb/issues/18563) that 
were fixed in beta 14 (without a notice). Updating test to reflect that.

- [x] Rebased/mergeable
- [x] Tests pass
