### PR TITLE
fix: Avoiding panic in Find*ByName methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.4.0 [in progress]
 ### Bug fixes 
 1. [#152](https://github.com/influxdata/influxdb-client-go/pull/152) Allow connecting to server on a URL path
+1. [#155](https://github.com/influxdata/influxdb-client-go/pull/155) Fix panic in FindOrganizationByName in case of no permissions
 
 ## 1.3.0 [2020-06-19]
 ### Features

--- a/api/buckets.go
+++ b/api/buckets.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"github.com/influxdata/influxdb-client-go/domain"
 )
 
@@ -103,7 +104,11 @@ func (b *bucketsApiImpl) FindBucketByName(ctx context.Context, bucketName string
 	if response.JSONDefault != nil {
 		return nil, domain.DomainErrorToError(response.JSONDefault, response.StatusCode())
 	}
-	return &(*response.JSON200.Buckets)[0], nil
+	if response.JSON200.Buckets != nil && len(*response.JSON200.Buckets) > 0 {
+		return &(*response.JSON200.Buckets)[0], nil
+	} else {
+		return nil, fmt.Errorf("bucket '%s' not found", bucketName)
+	}
 }
 
 func (b *bucketsApiImpl) FindBucketById(ctx context.Context, bucketId string) (*domain.Bucket, error) {


### PR DESCRIPTION
Closes #151

Properly validating returned collection that contains items. It was expected that the server always returns an error instead of returning an empty result set, as it does in other cases

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
