### PR TITLE
test(e2e): E2E tests split

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,15 @@
 # Golang CircleCI 2.0 configuration file
 #
 # Check https://circleci.com/docs/2.0/language-go/ for more details
-version: 2
+version: 2.1
 jobs:
   build:
-    docker:
-      # specify the version
-      - image: circleci/golang:1.13.0
-        environment:
-          ENV: CI
-          GO111MODULE: "on"
-      - image: quay.io/influxdb/influxdb:2.0.0-beta
-
+    machine: true
+    environment:
+      ENV: CI
+      GO111MODULE: "on"
+      INFLUXDB2_URL: "http://localhost:9999"
+      INFLUXDB2_ONBOARDING_URL: "http://localhost:9990"
     steps:
       - checkout
 #      - run:
@@ -30,17 +28,24 @@ jobs:
 #              echo modules are not tidy, please run 'go fmt ./...'
 #              exit 1
 #            fi
-      - run: go get -v -t -d ./...
-      - run: go vet ./...
-      - run: go get honnef.co/go/tools/cmd/staticcheck  && staticcheck --checks="all" --tags e2e ./...
       - run:
           name: "Create a temp directory for artifacts"
           command: |
             mkdir -p /tmp/artifacts
             mkdir -p /tmp/test-results
+      - run: sudo rm -rf /usr/local/go
+      - run: wget https://golang.org/dl/go1.13.14.linux-amd64.tar.gz -O /tmp/go.tgz
+      - run: sudo tar -C /usr/local -xzf /tmp/go.tgz
+      - run: go version
+      - run: go get -v -t -d ./...
+      - run: go vet  ./...
+      - run: go get honnef.co/go/tools/cmd/staticcheck  && staticcheck --checks='all' --tags e2e ./...
+      - run:
+          name: "Start InfluxDB service"
+          command: ./scripts/influxdb-restart.sh
       - run:
           command: |
-            gotestsum --junitfile /tmp/test-results/unit-tests.xml -- -race -coverprofile=coverage.txt -covermode=atomic -coverpkg '.,./api/...,./internal/...' -tags e2e ./...
+            go get gotest.tools/gotestsum && gotestsum --junitfile /tmp/test-results/unit-tests.xml -- -race -coverprofile=coverage.txt -covermode=atomic -coverpkg '.,./api/...,./internal/...' -tags e2e ./...
             bash <(curl -s https://codecov.io/bash)
             go tool cover -html=coverage.txt -o /tmp/artifacts/coverage.html
       - store_artifacts:

--- a/api/authorizations_e2e_test.go
+++ b/api/authorizations_e2e_test.go
@@ -1,0 +1,105 @@
+// +build e2e
+
+// Copyright 2020 InfluxData, Inc. All rights reserved.
+// Use of this source code is governed by MIT
+// license that can be found in the LICENSE file.
+
+package api_test
+
+import (
+	"context"
+	influxdb2 "github.com/influxdata/influxdb-client-go"
+	"github.com/influxdata/influxdb-client-go/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+var authToken string
+var serverURL string
+
+func getEnvValue(key, defVal string) string {
+	if val, ok := os.LookupEnv(key); ok {
+		return val
+	} else {
+		return defVal
+	}
+}
+
+func init() {
+	authToken = getEnvValue("INFLUXDB2_TOKEN", "my-token")
+	serverURL = getEnvValue("INFLUXDB2_URL", "http://localhost:9999")
+}
+
+func TestAuthorizationsAPI(t *testing.T) {
+	client := influxdb2.NewClient(serverURL, authToken)
+	authAPI := client.AuthorizationsAPI()
+	listRes, err := authAPI.GetAuthorizations(context.Background())
+	require.Nil(t, err)
+	require.NotNil(t, listRes)
+	assert.Len(t, *listRes, 1)
+
+	orgName := "my-org"
+	org, err := client.OrganizationsAPI().FindOrganizationByName(context.Background(), orgName)
+	require.Nil(t, err)
+	require.NotNil(t, org)
+	assert.Equal(t, orgName, org.Name)
+
+	permission := &domain.Permission{
+		Action: domain.PermissionActionWrite,
+		Resource: domain.Resource{
+			Type: domain.ResourceTypeBuckets,
+		},
+	}
+	permissions := []domain.Permission{*permission}
+
+	auth, err := authAPI.CreateAuthorizationWithOrgID(context.Background(), *org.Id, permissions)
+	require.Nil(t, err)
+	require.NotNil(t, auth)
+	assert.Equal(t, domain.AuthorizationUpdateRequestStatusActive, *auth.Status, *auth.Status)
+
+	listRes, err = authAPI.GetAuthorizations(context.Background())
+	require.Nil(t, err)
+	require.NotNil(t, listRes)
+	assert.Len(t, *listRes, 2)
+
+	listRes, err = authAPI.FindAuthorizationsByUserName(context.Background(), "my-user")
+	require.Nil(t, err)
+	require.NotNil(t, listRes)
+	assert.Len(t, *listRes, 2)
+
+	listRes, err = authAPI.FindAuthorizationsByOrgID(context.Background(), *org.Id)
+	require.Nil(t, err)
+	require.NotNil(t, listRes)
+	assert.Len(t, *listRes, 2)
+
+	listRes, err = authAPI.FindAuthorizationsByOrgName(context.Background(), "my-org")
+	require.Nil(t, err)
+	require.NotNil(t, listRes)
+	assert.Len(t, *listRes, 2)
+
+	listRes, err = authAPI.FindAuthorizationsByOrgName(context.Background(), "not-existent-org")
+	require.Nil(t, listRes)
+	require.NotNil(t, err)
+	//assert.Len(t, *listRes, 0)
+
+	auth, err = authAPI.UpdateAuthorizationStatus(context.Background(), auth, domain.AuthorizationUpdateRequestStatusInactive)
+	require.Nil(t, err)
+	require.NotNil(t, auth)
+	assert.Equal(t, domain.AuthorizationUpdateRequestStatusInactive, *auth.Status, *auth.Status)
+
+	listRes, err = authAPI.GetAuthorizations(context.Background())
+	require.Nil(t, err)
+	require.NotNil(t, listRes)
+	assert.Len(t, *listRes, 2)
+
+	err = authAPI.DeleteAuthorization(context.Background(), auth)
+	require.Nil(t, err)
+
+	listRes, err = authAPI.GetAuthorizations(context.Background())
+	require.Nil(t, err)
+	require.NotNil(t, listRes)
+	assert.Len(t, *listRes, 1)
+
+}

--- a/api/buckets_e2e_test.go
+++ b/api/buckets_e2e_test.go
@@ -1,0 +1,266 @@
+// +build e2e
+
+// Copyright 2020 InfluxData, Inc. All rights reserved.
+// Use of this source code is governed by MIT
+// license that can be found in the LICENSE file.
+
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	influxdb2 "github.com/influxdata/influxdb-client-go"
+	"github.com/influxdata/influxdb-client-go/api"
+	"github.com/influxdata/influxdb-client-go/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBucketsAPI(t *testing.T) {
+	ctx := context.Background()
+	client := influxdb2.NewClient(serverURL, authToken)
+
+	bucketsAPI := client.BucketsAPI()
+
+	buckets, err := bucketsAPI.GetBuckets(ctx)
+	require.Nil(t, err, err)
+	require.NotNil(t, buckets)
+	//at least three buckets, my-bucket and two system buckets.
+	assert.True(t, len(*buckets) > 2)
+
+	// test find existing bucket
+	bucket, err := bucketsAPI.FindBucketByName(ctx, "my-bucket")
+	require.Nil(t, err, err)
+	require.NotNil(t, bucket)
+	assert.Equal(t, "my-bucket", bucket.Name)
+
+	//test find non-existing bucket
+	bucket, err = bucketsAPI.FindBucketByName(ctx, "not existing bucket")
+	assert.NotNil(t, err)
+	assert.Nil(t, bucket)
+
+	// create organizatiton for bucket
+	org, err := client.OrganizationsAPI().CreateOrganizationWithName(ctx, "bucket-org")
+	require.Nil(t, err)
+	require.NotNil(t, org)
+
+	// collect all buckets including system ones created for new organization
+	buckets, err = bucketsAPI.GetBuckets(ctx)
+	require.Nil(t, err, err)
+	//store #all buckets before creating new ones
+	bucketsNum := len(*buckets)
+
+	name := "bucket-x"
+	b, err := bucketsAPI.CreateBucketWithName(ctx, org, name, domain.RetentionRule{EverySeconds: 3600 * 1}, domain.RetentionRule{EverySeconds: 3600 * 24})
+	require.Nil(t, err, err)
+	require.NotNil(t, b)
+	assert.Equal(t, name, b.Name)
+	assert.Len(t, b.RetentionRules, 1)
+
+	// Test update
+	desc := "bucket description"
+	b.Description = &desc
+	b.RetentionRules = []domain.RetentionRule{{EverySeconds: 60}}
+	b, err = bucketsAPI.UpdateBucket(ctx, b)
+	require.Nil(t, err, err)
+	require.NotNil(t, b)
+	assert.Equal(t, name, b.Name)
+	assert.Equal(t, desc, *b.Description)
+	assert.Len(t, b.RetentionRules, 1)
+
+	// Test owners
+	userOwner, err := client.UsersAPI().CreateUserWithName(ctx, "bucket-owner")
+	require.Nil(t, err, err)
+	require.NotNil(t, userOwner)
+
+	owners, err := bucketsAPI.GetOwners(ctx, b)
+	require.Nil(t, err, err)
+	require.NotNil(t, owners)
+	assert.Len(t, *owners, 0)
+
+	owner, err := bucketsAPI.AddOwner(ctx, b, userOwner)
+	require.Nil(t, err, err)
+	require.NotNil(t, owner)
+	assert.Equal(t, *userOwner.Id, *owner.Id)
+
+	owners, err = bucketsAPI.GetOwners(ctx, b)
+	require.Nil(t, err, err)
+	require.NotNil(t, owners)
+	assert.Len(t, *owners, 1)
+
+	err = bucketsAPI.RemoveOwnerWithID(ctx, *b.Id, *(&(*owners)[0]).Id)
+	require.Nil(t, err, err)
+
+	owners, err = bucketsAPI.GetOwners(ctx, b)
+	require.Nil(t, err, err)
+	require.NotNil(t, owners)
+	assert.Len(t, *owners, 0)
+
+	//test failures
+	_, err = bucketsAPI.AddOwnerWithID(ctx, "000000000000000", *userOwner.Id)
+	assert.NotNil(t, err)
+
+	_, err = bucketsAPI.AddOwnerWithID(ctx, *b.Id, "000000000000000")
+	assert.NotNil(t, err)
+
+	_, err = bucketsAPI.GetOwnersWithID(ctx, "000000000000000")
+	assert.NotNil(t, err)
+
+	err = bucketsAPI.RemoveOwnerWithID(ctx, *b.Id, "000000000000000")
+	assert.NotNil(t, err)
+
+	err = bucketsAPI.RemoveOwnerWithID(ctx, "000000000000000", *userOwner.Id)
+	assert.NotNil(t, err)
+
+	// Test members
+	userMember, err := client.UsersAPI().CreateUserWithName(ctx, "bucket-member")
+	require.Nil(t, err, err)
+	require.NotNil(t, userMember)
+
+	members, err := bucketsAPI.GetMembers(ctx, b)
+	require.Nil(t, err, err)
+	require.NotNil(t, members)
+	assert.Len(t, *members, 0)
+
+	member, err := bucketsAPI.AddMember(ctx, b, userMember)
+	require.Nil(t, err, err)
+	require.NotNil(t, member)
+	assert.Equal(t, *userMember.Id, *member.Id)
+
+	members, err = bucketsAPI.GetMembers(ctx, b)
+	require.Nil(t, err, err)
+	require.NotNil(t, members)
+	assert.Len(t, *members, 1)
+
+	err = bucketsAPI.RemoveMemberWithID(ctx, *b.Id, *(&(*members)[0]).Id)
+	require.Nil(t, err, err)
+
+	members, err = bucketsAPI.GetMembers(ctx, b)
+	require.Nil(t, err, err)
+	require.NotNil(t, members)
+	assert.Len(t, *members, 0)
+
+	//test failures
+	_, err = bucketsAPI.AddMemberWithID(ctx, "000000000000000", *userMember.Id)
+	assert.NotNil(t, err)
+
+	_, err = bucketsAPI.AddMemberWithID(ctx, *b.Id, "000000000000000")
+	assert.NotNil(t, err)
+
+	_, err = bucketsAPI.GetMembersWithID(ctx, "000000000000000")
+	assert.NotNil(t, err)
+
+	err = bucketsAPI.RemoveMemberWithID(ctx, *b.Id, "000000000000000")
+	assert.NotNil(t, err)
+
+	err = bucketsAPI.RemoveMemberWithID(ctx, "000000000000000", *userMember.Id)
+	assert.NotNil(t, err)
+
+	err = bucketsAPI.DeleteBucketWithID(ctx, *b.Id)
+	assert.Nil(t, err, err)
+
+	err = client.UsersAPI().DeleteUser(ctx, userOwner)
+	assert.Nil(t, err, err)
+
+	err = client.UsersAPI().DeleteUser(ctx, userMember)
+	assert.Nil(t, err, err)
+
+	//test failures
+	_, err = bucketsAPI.FindBucketByID(ctx, *b.Id)
+	assert.NotNil(t, err)
+
+	_, err = bucketsAPI.UpdateBucket(ctx, b)
+	assert.NotNil(t, err)
+
+	b.OrgID = b.Id
+	_, err = bucketsAPI.CreateBucket(ctx, b)
+	assert.NotNil(t, err)
+
+	// create bucket by object
+	b = &domain.Bucket{
+		Description:    &desc,
+		Name:           name,
+		OrgID:          org.Id,
+		RetentionRules: []domain.RetentionRule{{EverySeconds: 3600}},
+	}
+
+	b, err = bucketsAPI.CreateBucket(ctx, b)
+	require.Nil(t, err, err)
+	require.NotNil(t, b)
+	assert.Equal(t, name, b.Name)
+	assert.Equal(t, *org.Id, *b.OrgID)
+	assert.Equal(t, desc, *b.Description)
+	assert.Len(t, b.RetentionRules, 1)
+
+	// fail duplicit name
+	_, err = bucketsAPI.CreateBucketWithName(ctx, org, b.Name)
+	assert.NotNil(t, err)
+
+	// fail org not found
+	_, err = bucketsAPI.CreateBucketWithNameWithID(ctx, *b.Id, b.Name)
+	assert.NotNil(t, err)
+
+	err = bucketsAPI.DeleteBucketWithID(ctx, *b.Id)
+	assert.Nil(t, err, err)
+
+	err = bucketsAPI.DeleteBucketWithID(ctx, *b.Id)
+	assert.NotNil(t, err)
+
+	// create new buckets inside org
+	for i := 0; i < 30; i++ {
+		name := fmt.Sprintf("bucket-%03d", i)
+		b, err := bucketsAPI.CreateBucketWithName(ctx, org, name)
+		require.Nil(t, err, err)
+		require.NotNil(t, b)
+		assert.Equal(t, name, b.Name)
+	}
+
+	// test paging, 1st page
+	buckets, err = bucketsAPI.GetBuckets(ctx)
+	require.Nil(t, err, err)
+	require.NotNil(t, buckets)
+	assert.Len(t, *buckets, 20)
+	// test paging, 2nd, last page
+	buckets, err = bucketsAPI.GetBuckets(ctx, api.PagingWithOffset(20))
+	require.Nil(t, err, err)
+	require.NotNil(t, buckets)
+	//+2 is a bug, when using offset>4 there are returned also system buckets
+	assert.Len(t, *buckets, 10+2+bucketsNum)
+	// test paging with increase limit to cover all buckets
+	buckets, err = bucketsAPI.GetBuckets(ctx, api.PagingWithLimit(100))
+	require.Nil(t, err, err)
+	require.NotNil(t, buckets)
+	assert.Len(t, *buckets, 30+bucketsNum)
+	// test filtering buckets by org id
+	buckets, err = bucketsAPI.FindBucketsByOrgID(ctx, *org.Id, api.PagingWithLimit(100))
+	require.Nil(t, err, err)
+	require.NotNil(t, buckets)
+	assert.Len(t, *buckets, 30+2)
+	// test filtering buckets by org name
+	buckets, err = bucketsAPI.FindBucketsByOrgName(ctx, org.Name, api.PagingWithLimit(100))
+	require.Nil(t, err, err)
+	require.NotNil(t, buckets)
+	assert.Len(t, *buckets, 30+2)
+	// delete buckete
+	for _, b := range *buckets {
+		if strings.HasPrefix(b.Name, "bucket-") {
+			err = bucketsAPI.DeleteBucket(ctx, &b)
+			assert.Nil(t, err, err)
+		}
+	}
+	// check all created buckets deleted
+	buckets, err = bucketsAPI.FindBucketsByOrgName(ctx, org.Name, api.PagingWithLimit(100))
+	require.Nil(t, err, err)
+	require.NotNil(t, buckets)
+	assert.Len(t, *buckets, 2)
+
+	err = client.OrganizationsAPI().DeleteOrganization(ctx, org)
+	assert.Nil(t, err, err)
+
+	// should fail with org not found
+	_, err = bucketsAPI.FindBucketsByOrgName(ctx, org.Name, api.PagingWithLimit(100))
+	assert.NotNil(t, err)
+}

--- a/api/delete_e2e_test.go
+++ b/api/delete_e2e_test.go
@@ -1,0 +1,91 @@
+// +build e2e
+
+// Copyright 2020 InfluxData, Inc. All rights reserved.
+// Use of this source code is governed by MIT
+// license that can be found in the LICENSE file.
+
+package api_test
+
+import (
+	"context"
+	"github.com/influxdata/influxdb-client-go/api/write"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	influxdb2 "github.com/influxdata/influxdb-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteAPI(t *testing.T) {
+	ctx := context.Background()
+	client := influxdb2.NewClient(serverURL, authToken)
+	writeAPI := client.WriteAPIBlocking("my-org", "my-bucket")
+	queryAPI := client.QueryAPI("my-org")
+	tmStart := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	writeF := func(start time.Time, count int64) time.Time {
+		tm := start
+		for i, f := int64(0), 0.0; i < count; i++ {
+			p := write.NewPoint("test",
+				map[string]string{"a": strconv.FormatInt(i%2, 10), "b": "static"},
+				map[string]interface{}{"f": f, "i": i},
+				tm)
+			err := writeAPI.WritePoint(ctx, p)
+			require.Nil(t, err, err)
+			f += 1.2
+			tm = tm.Add(time.Minute)
+		}
+		return tm
+	}
+	countF := func(start, stop time.Time) int64 {
+		result, err := queryAPI.Query(ctx, `from(bucket:"my-bucket")|> range(start: `+start.Format(time.RFC3339)+`, stop:`+stop.Format(time.RFC3339)+`) 
+		|> filter(fn: (r) => r._measurement == "test" and r._field == "f")
+		|> drop(columns: ["a", "b"])
+		|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+		|> count(column: "f")`)
+
+		require.Nil(t, err, err)
+		count := int64(0)
+		if result.Next() {
+			require.NotNil(t, result.Record().ValueByKey("f"))
+			count = result.Record().ValueByKey("f").(int64)
+		}
+		return count
+	}
+	tmEnd := writeF(tmStart, 100)
+	assert.Equal(t, int64(100), countF(tmStart, tmEnd))
+	deleteAPI := client.DeleteAPI()
+
+	org, err := client.OrganizationsAPI().FindOrganizationByName(ctx, "my-org")
+	require.Nil(t, err, err)
+	require.NotNil(t, org)
+
+	bucket, err := client.BucketsAPI().FindBucketByName(ctx, "my-bucket")
+	require.Nil(t, err, err)
+	require.NotNil(t, bucket)
+
+	err = deleteAPI.DeleteWithName(ctx, "my-org", "my-bucket", tmStart, tmEnd, "")
+	require.Nil(t, err, err)
+	assert.Equal(t, int64(0), countF(tmStart, tmEnd))
+
+	tmEnd = writeF(tmStart, 100)
+	assert.Equal(t, int64(100), countF(tmStart, tmEnd))
+
+	err = deleteAPI.DeleteWithID(ctx, *org.Id, *bucket.Id, tmStart, tmEnd, "a=1")
+	require.Nil(t, err, err)
+	assert.Equal(t, int64(50), countF(tmStart, tmEnd))
+
+	err = deleteAPI.Delete(ctx, org, bucket, tmStart.Add(50*time.Minute), tmEnd, "b=static")
+	require.Nil(t, err, err)
+	assert.Equal(t, int64(25), countF(tmStart, tmEnd))
+
+	err = deleteAPI.DeleteWithName(ctx, "org", "my-bucket", tmStart.Add(50*time.Minute), tmEnd, "b=static")
+	require.NotNil(t, err, err)
+	assert.True(t, strings.Contains(err.Error(), "not found"))
+
+	err = deleteAPI.DeleteWithName(ctx, "my-org", "bucket", tmStart.Add(50*time.Minute), tmEnd, "b=static")
+	require.NotNil(t, err, err)
+	assert.True(t, strings.Contains(err.Error(), "not found"))
+}

--- a/api/labels_e2e_test.go
+++ b/api/labels_e2e_test.go
@@ -1,0 +1,152 @@
+// +build e2e
+
+// Copyright 2020 InfluxData, Inc. All rights reserved.
+// Use of this source code is governed by MIT
+// license that can be found in the LICENSE file.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	influxdb2 "github.com/influxdata/influxdb-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabelsAPI(t *testing.T) {
+	client := influxdb2.NewClientWithOptions(serverURL, authToken, influxdb2.DefaultOptions().SetLogLevel(3))
+	labelsAPI := client.LabelsAPI()
+	orgAPI := client.OrganizationsAPI()
+
+	ctx := context.Background()
+
+	myorg, err := orgAPI.FindOrganizationByName(ctx, "my-org")
+	require.Nil(t, err, err)
+	require.NotNil(t, myorg)
+
+	labels, err := labelsAPI.GetLabels(ctx)
+	require.Nil(t, err, err)
+	require.NotNil(t, labels)
+	assert.Len(t, *labels, 0)
+
+	labelName := "Active State"
+	props := map[string]string{"color": "#33ffddd", "description": "Marks org active"}
+	label, err := labelsAPI.CreateLabelWithName(ctx, myorg, labelName, props)
+	require.Nil(t, err, err)
+	require.NotNil(t, label)
+	assert.Equal(t, labelName, *label.Name)
+	require.NotNil(t, label.Properties)
+	assert.Equal(t, props, label.Properties.AdditionalProperties)
+
+	//remove properties
+	label.Properties.AdditionalProperties = map[string]string{"color": "", "description": ""}
+	label2, err := labelsAPI.UpdateLabel(ctx, label)
+	require.Nil(t, err, err)
+	require.NotNil(t, label2)
+	assert.Equal(t, labelName, *label2.Name)
+	assert.Nil(t, label2.Properties)
+
+	label2, err = labelsAPI.FindLabelByID(ctx, *label.Id)
+	require.Nil(t, err, err)
+	require.NotNil(t, label2)
+	assert.Equal(t, labelName, *label2.Name)
+
+	label2, err = labelsAPI.FindLabelByID(ctx, "000000000000000")
+	require.NotNil(t, err, err)
+	require.Nil(t, label2)
+
+	label2, err = labelsAPI.FindLabelByName(ctx, *myorg.Id, labelName)
+	require.Nil(t, err, err)
+	require.NotNil(t, label2)
+	assert.Equal(t, labelName, *label2.Name)
+
+	label2, err = labelsAPI.FindLabelByName(ctx, *myorg.Id, "wrong label")
+	require.NotNil(t, err, err)
+	require.Nil(t, label2)
+
+	labels, err = labelsAPI.GetLabels(ctx)
+	require.Nil(t, err, err)
+	require.NotNil(t, labels)
+	assert.Len(t, *labels, 1)
+
+	labels, err = labelsAPI.FindLabelsByOrg(ctx, myorg)
+	require.Nil(t, err, err)
+	require.NotNil(t, labels)
+	assert.Len(t, *labels, 1)
+
+	labels, err = labelsAPI.FindLabelsByOrgID(ctx, *myorg.Id)
+	require.Nil(t, err, err)
+	require.NotNil(t, labels)
+	assert.Len(t, *labels, 1)
+
+	labels, err = labelsAPI.FindLabelsByOrgID(ctx, "000000000000000")
+	require.NotNil(t, err, err)
+	require.Nil(t, labels)
+
+	// duplicate label
+	label2, err = labelsAPI.CreateLabelWithName(ctx, myorg, labelName, nil)
+	require.NotNil(t, err, err)
+	require.Nil(t, label2)
+
+	labels, err = orgAPI.GetLabels(ctx, myorg)
+	require.Nil(t, err, err)
+	require.NotNil(t, labels)
+	assert.Len(t, *labels, 0)
+
+	org, err := orgAPI.CreateOrganizationWithName(ctx, "org1")
+	require.Nil(t, err, err)
+	require.NotNil(t, org)
+
+	labels, err = orgAPI.GetLabels(ctx, org)
+	require.Nil(t, err, err)
+	require.NotNil(t, labels)
+	assert.Len(t, *labels, 0)
+
+	labelx, err := orgAPI.AddLabel(ctx, org, label)
+	require.Nil(t, err, err)
+	require.NotNil(t, labelx)
+
+	labels, err = orgAPI.GetLabels(ctx, org)
+	require.Nil(t, err, err)
+	require.NotNil(t, labels)
+	assert.Len(t, *labels, 1)
+
+	err = orgAPI.RemoveLabel(ctx, org, label)
+	require.Nil(t, err, err)
+
+	labels, err = orgAPI.GetLabels(ctx, org)
+	require.Nil(t, err, err)
+	require.NotNil(t, labels)
+	assert.Len(t, *labels, 0)
+
+	labels, err = orgAPI.GetLabelsWithID(ctx, "000000000000000")
+	require.NotNil(t, err, err)
+	require.Nil(t, labels)
+
+	label2, err = orgAPI.AddLabelWithID(ctx, *org.Id, "000000000000000")
+	require.NotNil(t, err, err)
+	require.Nil(t, label2)
+
+	label2, err = orgAPI.AddLabelWithID(ctx, "000000000000000", "000000000000000")
+	require.NotNil(t, err, err)
+	require.Nil(t, label2)
+
+	err = orgAPI.RemoveLabelWithID(ctx, *org.Id, "000000000000000")
+	require.NotNil(t, err, err)
+	require.Nil(t, label2)
+
+	err = orgAPI.RemoveLabelWithID(ctx, "000000000000000", "000000000000000")
+	require.NotNil(t, err, err)
+	require.Nil(t, label2)
+
+	err = orgAPI.DeleteOrganization(ctx, org)
+	assert.Nil(t, err, err)
+
+	err = labelsAPI.DeleteLabel(ctx, label)
+	require.Nil(t, err, err)
+
+	err = labelsAPI.DeleteLabel(ctx, label)
+	require.NotNil(t, err, err)
+}

--- a/api/organizations_e2e_test.go
+++ b/api/organizations_e2e_test.go
@@ -1,0 +1,237 @@
+// +build e2e
+
+// Copyright 2020 InfluxData, Inc. All rights reserved.
+// Use of this source code is governed by MIT
+// license that can be found in the LICENSE file.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	influxdb2 "github.com/influxdata/influxdb-client-go"
+	"github.com/influxdata/influxdb-client-go/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrganizationsAPI(t *testing.T) {
+	client := influxdb2.NewClient(serverURL, authToken)
+	orgsAPI := client.OrganizationsAPI()
+	usersAPI := client.UsersAPI()
+	orgName := "my-org-2"
+	orgDescription := "my-org 2 description"
+	ctx := context.Background()
+	invalidID := "aaaaaaaaaaaaaaaa"
+
+	orgList, err := orgsAPI.GetOrganizations(ctx)
+	require.Nil(t, err)
+	require.NotNil(t, orgList)
+	assert.Len(t, *orgList, 1)
+
+	//test error
+	org, err := orgsAPI.CreateOrganizationWithName(ctx, "")
+	assert.NotNil(t, err)
+	require.Nil(t, org)
+
+	org, err = orgsAPI.CreateOrganizationWithName(ctx, orgName)
+	require.Nil(t, err)
+	require.NotNil(t, org)
+	assert.Equal(t, orgName, org.Name)
+
+	//test duplicit org
+	_, err = orgsAPI.CreateOrganizationWithName(ctx, orgName)
+	require.NotNil(t, err)
+
+	org.Description = &orgDescription
+
+	org, err = orgsAPI.UpdateOrganization(ctx, org)
+	require.Nil(t, err)
+	require.NotNil(t, org)
+	assert.Equal(t, orgDescription, *org.Description)
+
+	orgList, err = orgsAPI.GetOrganizations(ctx)
+
+	require.Nil(t, err)
+	require.NotNil(t, orgList)
+	assert.Len(t, *orgList, 2)
+
+	permission := &domain.Permission{
+		Action: domain.PermissionActionWrite,
+		Resource: domain.Resource{
+			Type: domain.ResourceTypeBuckets,
+		},
+	}
+	permissions := []domain.Permission{*permission}
+
+	//create authorization for new org
+	auth, err := client.AuthorizationsAPI().CreateAuthorizationWithOrgID(context.Background(), *org.Id, permissions)
+	require.Nil(t, err)
+	require.NotNil(t, auth)
+
+	// create client with new auth token without permission
+	clientOrg2 := influxdb2.NewClient(serverURL, *auth.Token)
+
+	orgList, err = clientOrg2.OrganizationsAPI().GetOrganizations(ctx)
+	require.Nil(t, err)
+	require.NotNil(t, orgList)
+	assert.Len(t, *orgList, 0)
+
+	org2, err := orgsAPI.FindOrganizationByName(ctx, orgName)
+	require.Nil(t, err)
+	require.NotNil(t, org2)
+
+	//find unknown org
+	org2, err = orgsAPI.FindOrganizationByName(ctx, "not-existetn-org")
+	assert.NotNil(t, err)
+	assert.Nil(t, org2)
+
+	//find org using token without org permission
+	org2, err = clientOrg2.OrganizationsAPI().FindOrganizationByName(ctx, org.Name)
+	assert.NotNil(t, err)
+	assert.Nil(t, org2)
+
+	err = client.AuthorizationsAPI().DeleteAuthorization(ctx, auth)
+	require.Nil(t, err)
+
+	members, err := orgsAPI.GetMembers(ctx, org)
+	require.Nil(t, err)
+	require.NotNil(t, members)
+	require.Len(t, *members, 0)
+
+	user, err := usersAPI.CreateUserWithName(ctx, "user-01")
+	require.Nil(t, err)
+	require.NotNil(t, user)
+
+	member, err := orgsAPI.AddMember(ctx, org, user)
+	require.Nil(t, err)
+	require.NotNil(t, member)
+	assert.Equal(t, *user.Id, *member.Id)
+	assert.Equal(t, user.Name, member.Name)
+
+	// Add member with invalid id
+	member, err = orgsAPI.AddMemberWithID(ctx, *org.Id, invalidID)
+	assert.NotNil(t, err)
+	assert.Nil(t, member)
+
+	members, err = orgsAPI.GetMembers(ctx, org)
+	require.Nil(t, err)
+	require.NotNil(t, members)
+	require.Len(t, *members, 1)
+
+	// get member with invalid id
+	members, err = orgsAPI.GetMembersWithID(ctx, invalidID)
+	assert.NotNil(t, err)
+	assert.Nil(t, members)
+
+	org2, err = orgsAPI.FindOrganizationByID(ctx, *org.Id)
+	require.Nil(t, err)
+	require.NotNil(t, org2)
+	assert.Equal(t, org.Name, org2.Name)
+
+	// find invalid id
+	org2, err = orgsAPI.FindOrganizationByID(ctx, invalidID)
+	assert.NotNil(t, err)
+	assert.Nil(t, org2)
+
+	orgs, err := orgsAPI.FindOrganizationsByUserID(ctx, *user.Id)
+	require.Nil(t, err)
+	require.NotNil(t, orgs)
+	require.Len(t, *orgs, 1)
+	assert.Equal(t, org.Name, (*orgs)[0].Name)
+
+	// look for not existent
+	orgs, err = orgsAPI.FindOrganizationsByUserID(ctx, invalidID)
+	assert.Nil(t, err)
+	assert.NotNil(t, orgs)
+	assert.Len(t, *orgs, 0)
+
+	orgName2 := "my-org-3"
+
+	org2, err = orgsAPI.CreateOrganizationWithName(ctx, orgName2)
+	require.Nil(t, err)
+	require.NotNil(t, org2)
+	assert.Equal(t, orgName2, org2.Name)
+
+	orgList, err = orgsAPI.GetOrganizations(ctx)
+	require.Nil(t, err)
+	require.NotNil(t, orgList)
+	assert.Len(t, *orgList, 3)
+
+	owners, err := orgsAPI.GetOwners(ctx, org2)
+	assert.Nil(t, err)
+	assert.NotNil(t, owners)
+	assert.Len(t, *owners, 1)
+
+	//get owners with invalid id
+	owners, err = orgsAPI.GetOwnersWithID(ctx, invalidID)
+	assert.NotNil(t, err)
+	assert.Nil(t, owners)
+
+	owner, err := orgsAPI.AddOwner(ctx, org2, user)
+	require.Nil(t, err)
+	require.NotNil(t, owner)
+
+	// add owner with invalid ID
+	owner, err = orgsAPI.AddOwnerWithID(ctx, *org2.Id, invalidID)
+	assert.NotNil(t, err)
+	assert.Nil(t, owner)
+
+	owners, err = orgsAPI.GetOwners(ctx, org2)
+	require.Nil(t, err)
+	require.NotNil(t, owners)
+	assert.Len(t, *owners, 2)
+
+	u, err := usersAPI.FindUserByName(ctx, "my-user")
+	require.Nil(t, err)
+	require.NotNil(t, u)
+
+	err = orgsAPI.RemoveOwner(ctx, org2, u)
+	require.Nil(t, err)
+
+	// remove owner with invalid ID
+	err = orgsAPI.RemoveOwnerWithID(ctx, invalidID, invalidID)
+	assert.NotNil(t, err)
+
+	owners, err = orgsAPI.GetOwners(ctx, org2)
+	require.Nil(t, err)
+	require.NotNil(t, owners)
+	assert.Len(t, *owners, 1)
+
+	orgs, err = orgsAPI.FindOrganizationsByUserID(ctx, *user.Id)
+	require.Nil(t, err)
+	require.NotNil(t, orgs)
+	require.Len(t, *orgs, 2)
+
+	err = orgsAPI.RemoveMember(ctx, org, user)
+	require.Nil(t, err)
+
+	// remove invalid memberID
+	err = orgsAPI.RemoveMemberWithID(ctx, invalidID, invalidID)
+	assert.NotNil(t, err)
+
+	members, err = orgsAPI.GetMembers(ctx, org)
+	require.Nil(t, err)
+	require.NotNil(t, members)
+	require.Len(t, *members, 0)
+
+	err = orgsAPI.DeleteOrganization(ctx, org)
+	require.Nil(t, err)
+
+	err = orgsAPI.DeleteOrganization(ctx, org2)
+	assert.Nil(t, err)
+
+	// delete invalid org
+	err = orgsAPI.DeleteOrganizationWithID(ctx, invalidID)
+	assert.NotNil(t, err)
+
+	orgList, err = orgsAPI.GetOrganizations(ctx)
+	require.Nil(t, err)
+	require.NotNil(t, orgList)
+	assert.Len(t, *orgList, 1)
+
+	err = usersAPI.DeleteUser(ctx, user)
+	require.Nil(t, err)
+
+}

--- a/api/users_e2e_test.go
+++ b/api/users_e2e_test.go
@@ -1,0 +1,63 @@
+// +build e2e
+
+// Copyright 2020 InfluxData, Inc. All rights reserved.
+// Use of this source code is governed by MIT
+// license that can be found in the LICENSE file.
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	influxdb2 "github.com/influxdata/influxdb-client-go"
+	"github.com/influxdata/influxdb-client-go/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsersAPI(t *testing.T) {
+	client := influxdb2.NewClient(serverURL, authToken)
+
+	usersAPI := client.UsersAPI()
+
+	me, err := usersAPI.Me(context.Background())
+	require.Nil(t, err)
+	require.NotNil(t, me)
+
+	users, err := usersAPI.GetUsers(context.Background())
+	require.Nil(t, err)
+	require.NotNil(t, users)
+	assert.Len(t, *users, 1)
+
+	user, err := usersAPI.CreateUserWithName(context.Background(), "user-01")
+	require.Nil(t, err)
+	require.NotNil(t, user)
+
+	users, err = usersAPI.GetUsers(context.Background())
+	require.Nil(t, err)
+	require.NotNil(t, users)
+	assert.Len(t, *users, 2)
+
+	status := domain.UserStatusInactive
+	user.Status = &status
+	user, err = usersAPI.UpdateUser(context.Background(), user)
+	require.Nil(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, status, *user.Status)
+
+	user, err = usersAPI.FindUserByID(context.Background(), *user.Id)
+	require.Nil(t, err)
+	require.NotNil(t, user)
+
+	err = usersAPI.UpdateUserPassword(context.Background(), user, "my-password")
+	require.Nil(t, err)
+
+	err = usersAPI.DeleteUser(context.Background(), user)
+	require.Nil(t, err)
+
+	users, err = usersAPI.GetUsers(context.Background())
+	require.Nil(t, err)
+	require.NotNil(t, users)
+	assert.Len(t, *users, 1)
+}

--- a/client.go
+++ b/client.go
@@ -142,6 +142,7 @@ func NewClientWithOptions(serverURL string, authToken string, options *Options) 
 		apiClient:   domain.NewClientWithResponses(service),
 	}
 	log.Log.SetDebugLevel(client.Options().LogLevel())
+	log.Log.Infof("Using URL '%s', token '%s'", serverURL, authToken)
 	return client
 }
 func (c *clientImpl) Options() *Options {

--- a/client_e2e_deprecated_test.go
+++ b/client_e2e_deprecated_test.go
@@ -22,23 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSetup(t *testing.T) {
-	client := influxdb2.NewClientWithOptions("http://localhost:9999", "", influxdb2.DefaultOptions().SetLogLevel(2))
-	response, err := client.Setup(context.Background(), "my-user", "my-password", "my-org", "my-bucket", 0)
-	if err != nil {
-		t.Error(err)
-	}
-	require.NotNil(t, response)
-	authToken = *response.Auth.Token
-	fmt.Println("Token:" + authToken)
-
-	_, err = client.Setup(context.Background(), "my-user", "my-password", "my-org", "my-bucket", 0)
-	require.NotNil(t, err)
-	assert.Equal(t, "conflict: onboarding has already been completed", err.Error())
-}
-
 func TestWriteDeprecated(t *testing.T) {
-	client := influxdb2.NewClientWithOptions("http://localhost:9999", authToken, influxdb2.DefaultOptions().SetLogLevel(3))
+	client := influxdb2.NewClientWithOptions(serverURL, authToken, influxdb2.DefaultOptions().SetLogLevel(3))
 	writeAPI := client.WriteApi("my-org", "my-bucket")
 	errCh := writeAPI.Errors()
 	errorsCount := 0
@@ -76,7 +61,7 @@ func TestWriteDeprecated(t *testing.T) {
 }
 
 func TestQueryRawDeprecated(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
+	client := influxdb2.NewClient(serverURL, authToken)
 
 	queryAPI := client.QueryApi("my-org")
 	res, err := queryAPI.QueryRaw(context.Background(), `from(bucket:"my-bucket")|> range(start: -24h) |> filter(fn: (r) => r._measurement == "test")`, influxdb2.DefaultDialect())
@@ -89,7 +74,7 @@ func TestQueryRawDeprecated(t *testing.T) {
 }
 
 func TestQueryDeprecated(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
+	client := influxdb2.NewClient(serverURL, authToken)
 
 	queryAPI := client.QueryApi("my-org")
 	fmt.Println("QueryResult")
@@ -114,7 +99,7 @@ func TestQueryDeprecated(t *testing.T) {
 }
 
 func TestAuthorizationsApi(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
+	client := influxdb2.NewClient(serverURL, authToken)
 	authAPI := client.AuthorizationsApi()
 	listRes, err := authAPI.GetAuthorizations(context.Background())
 	require.Nil(t, err)
@@ -186,7 +171,7 @@ func TestAuthorizationsApi(t *testing.T) {
 }
 
 func TestOrganizations(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
+	client := influxdb2.NewClient(serverURL, authToken)
 	orgsAPI := client.OrganizationsApi()
 	usersAPI := client.UsersApi()
 	orgName := "my-org-2"
@@ -240,7 +225,7 @@ func TestOrganizations(t *testing.T) {
 	require.NotNil(t, auth)
 
 	// create client with new auth token without permission
-	clientOrg2 := influxdb2.NewClient("http://localhost:9999", *auth.Token)
+	clientOrg2 := influxdb2.NewClient(serverURL, *auth.Token)
 
 	orgList, err = clientOrg2.OrganizationsApi().GetOrganizations(ctx)
 	require.Nil(t, err)
@@ -405,7 +390,7 @@ func TestOrganizations(t *testing.T) {
 }
 
 func TestUsers(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
+	client := influxdb2.NewClient(serverURL, authToken)
 
 	usersAPI := client.UsersApi()
 
@@ -452,7 +437,7 @@ func TestUsers(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	ctx := context.Background()
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
+	client := influxdb2.NewClient(serverURL, authToken)
 	writeAPI := client.WriteApiBlocking("my-org", "my-bucket")
 	queryAPI := client.QueryApi("my-org")
 	tmStart := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -523,7 +508,7 @@ func TestDelete(t *testing.T) {
 
 func TestBuckets(t *testing.T) {
 	ctx := context.Background()
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
+	client := influxdb2.NewClient(serverURL, authToken)
 
 	bucketsAPI := client.BucketsApi()
 
@@ -768,7 +753,7 @@ func TestBuckets(t *testing.T) {
 }
 
 func TestLabels(t *testing.T) {
-	client := influxdb2.NewClientWithOptions("http://localhost:9999", authToken, influxdb2.DefaultOptions().SetLogLevel(3))
+	client := influxdb2.NewClientWithOptions(serverURL, authToken, influxdb2.DefaultOptions().SetLogLevel(3))
 	labelsAPI := client.LabelsApi()
 	orgAPI := client.OrganizationsApi()
 

--- a/client_e2e_test.go
+++ b/client_e2e_test.go
@@ -8,29 +8,54 @@ package influxdb2_test
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"github.com/influxdata/influxdb-client-go/api/write"
+	"os"
 	"strconv"
-	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go"
-	"github.com/influxdata/influxdb-client-go/api"
 	"github.com/influxdata/influxdb-client-go/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 var authToken string
+var serverURL string
+var onboardingURL string
+
+func getEnvValue(key, defVal string) string {
+	if val, ok := os.LookupEnv(key); ok {
+		return val
+	} else {
+		return defVal
+	}
+}
 
 func init() {
-	flag.StringVar(&authToken, "token", "", "authentication token")
+	authToken = getEnvValue("INFLUXDB2_TOKEN", "my-token")
+	serverURL = getEnvValue("INFLUXDB2_URL", "http://localhost:9999")
+	onboardingURL = getEnvValue("INFLUXDB2_ONBOARDING_URL", "http://localhost:9990")
+}
+
+func TestSetup(t *testing.T) {
+	client := influxdb2.NewClientWithOptions(onboardingURL, "", influxdb2.DefaultOptions().SetLogLevel(2))
+	response, err := client.Setup(context.Background(), "my-user", "my-password", "my-org", "my-bucket", 0)
+	if err != nil {
+		t.Error(err)
+	}
+	require.NotNil(t, response)
+	require.NotNil(t, response.Auth)
+	require.NotNil(t, response.Auth.Token)
+
+	_, err = client.Setup(context.Background(), "my-user", "my-password", "my-org", "my-bucket", 0)
+	require.NotNil(t, err)
+	assert.Equal(t, "conflict: onboarding has already been completed", err.Error())
 }
 
 func TestReady(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", "")
+	client := influxdb2.NewClient(serverURL, "")
 
 	ok, err := client.Ready(context.Background())
 	if err != nil {
@@ -42,7 +67,7 @@ func TestReady(t *testing.T) {
 }
 
 func TestHealth(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", "")
+	client := influxdb2.NewClient(serverURL, "")
 
 	health, err := client.Health(context.Background())
 	if err != nil {
@@ -53,15 +78,19 @@ func TestHealth(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	client := influxdb2.NewClientWithOptions("http://localhost:9999", authToken, influxdb2.DefaultOptions().SetLogLevel(3))
+	client := influxdb2.NewClientWithOptions(serverURL, authToken, influxdb2.DefaultOptions().SetLogLevel(3))
 	writeAPI := client.WriteAPI("my-org", "my-bucket")
 	errCh := writeAPI.Errors()
 	errorsCount := 0
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
 		for err := range errCh {
 			errorsCount++
-			fmt.Println("Write error: ", err.Error())
+			fmt.Println("Error proc: write error: ", err.Error())
 		}
+		fmt.Println("Error proc: finished ")
+		wg.Done()
 	}()
 	timestamp := time.Now()
 	for i, f := 0, 3.3; i < 10; i++ {
@@ -86,12 +115,13 @@ func TestWrite(t *testing.T) {
 	assert.Nil(t, err)
 
 	client.Close()
+	wg.Wait()
 	assert.Equal(t, 0, errorsCount)
 
 }
 
 func TestQueryRaw(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
+	client := influxdb2.NewClient(serverURL, authToken)
 
 	queryAPI := client.QueryAPI("my-org")
 	res, err := queryAPI.QueryRaw(context.Background(), `from(bucket:"my-bucket")|> range(start: -24h) |> filter(fn: (r) => r._measurement == "test")`, influxdb2.DefaultDialect())
@@ -104,7 +134,7 @@ func TestQueryRaw(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
+	client := influxdb2.NewClient(serverURL, authToken)
 
 	queryAPI := client.QueryAPI("my-org")
 	fmt.Println("QueryResult")
@@ -123,795 +153,4 @@ func TestQuery(t *testing.T) {
 		}
 	}
 
-}
-
-func TestAuthorizationsAPI(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
-	authAPI := client.AuthorizationsAPI()
-	listRes, err := authAPI.GetAuthorizations(context.Background())
-	require.Nil(t, err)
-	require.NotNil(t, listRes)
-	assert.Len(t, *listRes, 1)
-
-	orgName := "my-org"
-	org, err := client.OrganizationsAPI().FindOrganizationByName(context.Background(), orgName)
-	require.Nil(t, err)
-	require.NotNil(t, org)
-	assert.Equal(t, orgName, org.Name)
-
-	permission := &domain.Permission{
-		Action: domain.PermissionActionWrite,
-		Resource: domain.Resource{
-			Type: domain.ResourceTypeBuckets,
-		},
-	}
-	permissions := []domain.Permission{*permission}
-
-	auth, err := authAPI.CreateAuthorizationWithOrgID(context.Background(), *org.Id, permissions)
-	require.Nil(t, err)
-	require.NotNil(t, auth)
-	assert.Equal(t, domain.AuthorizationUpdateRequestStatusActive, *auth.Status, *auth.Status)
-
-	listRes, err = authAPI.GetAuthorizations(context.Background())
-	require.Nil(t, err)
-	require.NotNil(t, listRes)
-	assert.Len(t, *listRes, 2)
-
-	listRes, err = authAPI.FindAuthorizationsByUserName(context.Background(), "my-user")
-	require.Nil(t, err)
-	require.NotNil(t, listRes)
-	assert.Len(t, *listRes, 2)
-
-	listRes, err = authAPI.FindAuthorizationsByOrgID(context.Background(), *org.Id)
-	require.Nil(t, err)
-	require.NotNil(t, listRes)
-	assert.Len(t, *listRes, 2)
-
-	listRes, err = authAPI.FindAuthorizationsByOrgName(context.Background(), "my-org")
-	require.Nil(t, err)
-	require.NotNil(t, listRes)
-	assert.Len(t, *listRes, 2)
-
-	listRes, err = authAPI.FindAuthorizationsByOrgName(context.Background(), "not-existent-org")
-	require.Nil(t, listRes)
-	require.NotNil(t, err)
-	//assert.Len(t, *listRes, 0)
-
-	auth, err = authAPI.UpdateAuthorizationStatus(context.Background(), auth, domain.AuthorizationUpdateRequestStatusInactive)
-	require.Nil(t, err)
-	require.NotNil(t, auth)
-	assert.Equal(t, domain.AuthorizationUpdateRequestStatusInactive, *auth.Status, *auth.Status)
-
-	listRes, err = authAPI.GetAuthorizations(context.Background())
-	require.Nil(t, err)
-	require.NotNil(t, listRes)
-	assert.Len(t, *listRes, 2)
-
-	err = authAPI.DeleteAuthorization(context.Background(), auth)
-	require.Nil(t, err)
-
-	listRes, err = authAPI.GetAuthorizations(context.Background())
-	require.Nil(t, err)
-	require.NotNil(t, listRes)
-	assert.Len(t, *listRes, 1)
-
-}
-
-func TestOrganizationsAPI(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
-	orgsAPI := client.OrganizationsAPI()
-	usersAPI := client.UsersAPI()
-	orgName := "my-org-2"
-	orgDescription := "my-org 2 description"
-	ctx := context.Background()
-	invalidID := "aaaaaaaaaaaaaaaa"
-
-	orgList, err := orgsAPI.GetOrganizations(ctx)
-	require.Nil(t, err)
-	require.NotNil(t, orgList)
-	assert.Len(t, *orgList, 1)
-
-	//test error
-	org, err := orgsAPI.CreateOrganizationWithName(ctx, "")
-	assert.NotNil(t, err)
-	require.Nil(t, org)
-
-	org, err = orgsAPI.CreateOrganizationWithName(ctx, orgName)
-	require.Nil(t, err)
-	require.NotNil(t, org)
-	assert.Equal(t, orgName, org.Name)
-
-	//test duplicit org
-	_, err = orgsAPI.CreateOrganizationWithName(ctx, orgName)
-	require.NotNil(t, err)
-
-	org.Description = &orgDescription
-
-	org, err = orgsAPI.UpdateOrganization(ctx, org)
-	require.Nil(t, err)
-	require.NotNil(t, org)
-	assert.Equal(t, orgDescription, *org.Description)
-
-	orgList, err = orgsAPI.GetOrganizations(ctx)
-
-	require.Nil(t, err)
-	require.NotNil(t, orgList)
-	assert.Len(t, *orgList, 2)
-
-	permission := &domain.Permission{
-		Action: domain.PermissionActionWrite,
-		Resource: domain.Resource{
-			Type: domain.ResourceTypeBuckets,
-		},
-	}
-	permissions := []domain.Permission{*permission}
-
-	//create authorization for new org
-	auth, err := client.AuthorizationsAPI().CreateAuthorizationWithOrgID(context.Background(), *org.Id, permissions)
-	require.Nil(t, err)
-	require.NotNil(t, auth)
-
-	// create client with new auth token without permission
-	clientOrg2 := influxdb2.NewClient("http://localhost:9999", *auth.Token)
-
-	orgList, err = clientOrg2.OrganizationsAPI().GetOrganizations(ctx)
-	require.Nil(t, err)
-	require.NotNil(t, orgList)
-	assert.Len(t, *orgList, 0)
-
-	org2, err := orgsAPI.FindOrganizationByName(ctx, orgName)
-	require.Nil(t, err)
-	require.NotNil(t, org2)
-
-	//find unknown org
-	org2, err = orgsAPI.FindOrganizationByName(ctx, "not-existetn-org")
-	assert.NotNil(t, err)
-	assert.Nil(t, org2)
-
-	//find org using token without org permission
-	org2, err = clientOrg2.OrganizationsAPI().FindOrganizationByName(ctx, org.Name)
-	assert.NotNil(t, err)
-	assert.Nil(t, org2)
-
-	err = client.AuthorizationsAPI().DeleteAuthorization(ctx, auth)
-	require.Nil(t, err)
-
-	members, err := orgsAPI.GetMembers(ctx, org)
-	require.Nil(t, err)
-	require.NotNil(t, members)
-	require.Len(t, *members, 0)
-
-	user, err := usersAPI.CreateUserWithName(ctx, "user-01")
-	require.Nil(t, err)
-	require.NotNil(t, user)
-
-	member, err := orgsAPI.AddMember(ctx, org, user)
-	require.Nil(t, err)
-	require.NotNil(t, member)
-	assert.Equal(t, *user.Id, *member.Id)
-	assert.Equal(t, user.Name, member.Name)
-
-	// Add member with invalid id
-	member, err = orgsAPI.AddMemberWithID(ctx, *org.Id, invalidID)
-	assert.NotNil(t, err)
-	assert.Nil(t, member)
-
-	members, err = orgsAPI.GetMembers(ctx, org)
-	require.Nil(t, err)
-	require.NotNil(t, members)
-	require.Len(t, *members, 1)
-
-	// get member with invalid id
-	members, err = orgsAPI.GetMembersWithID(ctx, invalidID)
-	assert.NotNil(t, err)
-	assert.Nil(t, members)
-
-	org2, err = orgsAPI.FindOrganizationByID(ctx, *org.Id)
-	require.Nil(t, err)
-	require.NotNil(t, org2)
-	assert.Equal(t, org.Name, org2.Name)
-
-	// find invalid id
-	org2, err = orgsAPI.FindOrganizationByID(ctx, invalidID)
-	assert.NotNil(t, err)
-	assert.Nil(t, org2)
-
-	orgs, err := orgsAPI.FindOrganizationsByUserID(ctx, *user.Id)
-	require.Nil(t, err)
-	require.NotNil(t, orgs)
-	require.Len(t, *orgs, 1)
-	assert.Equal(t, org.Name, (*orgs)[0].Name)
-
-	// look for not existent
-	orgs, err = orgsAPI.FindOrganizationsByUserID(ctx, invalidID)
-	assert.Nil(t, err)
-	assert.NotNil(t, orgs)
-	assert.Len(t, *orgs, 0)
-
-	orgName2 := "my-org-3"
-
-	org2, err = orgsAPI.CreateOrganizationWithName(ctx, orgName2)
-	require.Nil(t, err)
-	require.NotNil(t, org2)
-	assert.Equal(t, orgName2, org2.Name)
-
-	orgList, err = orgsAPI.GetOrganizations(ctx)
-	require.Nil(t, err)
-	require.NotNil(t, orgList)
-	assert.Len(t, *orgList, 3)
-
-	owners, err := orgsAPI.GetOwners(ctx, org2)
-	assert.Nil(t, err)
-	assert.NotNil(t, owners)
-	assert.Len(t, *owners, 1)
-
-	//get owners with invalid id
-	owners, err = orgsAPI.GetOwnersWithID(ctx, invalidID)
-	assert.NotNil(t, err)
-	assert.Nil(t, owners)
-
-	owner, err := orgsAPI.AddOwner(ctx, org2, user)
-	require.Nil(t, err)
-	require.NotNil(t, owner)
-
-	// add owner with invalid ID
-	owner, err = orgsAPI.AddOwnerWithID(ctx, *org2.Id, invalidID)
-	assert.NotNil(t, err)
-	assert.Nil(t, owner)
-
-	owners, err = orgsAPI.GetOwners(ctx, org2)
-	require.Nil(t, err)
-	require.NotNil(t, owners)
-	assert.Len(t, *owners, 2)
-
-	u, err := usersAPI.FindUserByName(ctx, "my-user")
-	require.Nil(t, err)
-	require.NotNil(t, u)
-
-	err = orgsAPI.RemoveOwner(ctx, org2, u)
-	require.Nil(t, err)
-
-	// remove owner with invalid ID
-	err = orgsAPI.RemoveOwnerWithID(ctx, invalidID, invalidID)
-	assert.NotNil(t, err)
-
-	owners, err = orgsAPI.GetOwners(ctx, org2)
-	require.Nil(t, err)
-	require.NotNil(t, owners)
-	assert.Len(t, *owners, 1)
-
-	orgs, err = orgsAPI.FindOrganizationsByUserID(ctx, *user.Id)
-	require.Nil(t, err)
-	require.NotNil(t, orgs)
-	require.Len(t, *orgs, 2)
-
-	err = orgsAPI.RemoveMember(ctx, org, user)
-	require.Nil(t, err)
-
-	// remove invalid memberID
-	err = orgsAPI.RemoveMemberWithID(ctx, invalidID, invalidID)
-	assert.NotNil(t, err)
-
-	members, err = orgsAPI.GetMembers(ctx, org)
-	require.Nil(t, err)
-	require.NotNil(t, members)
-	require.Len(t, *members, 0)
-
-	err = orgsAPI.DeleteOrganization(ctx, org)
-	require.Nil(t, err)
-
-	err = orgsAPI.DeleteOrganization(ctx, org2)
-	assert.Nil(t, err)
-
-	// delete invalid org
-	err = orgsAPI.DeleteOrganizationWithID(ctx, invalidID)
-	assert.NotNil(t, err)
-
-	orgList, err = orgsAPI.GetOrganizations(ctx)
-	require.Nil(t, err)
-	require.NotNil(t, orgList)
-	assert.Len(t, *orgList, 1)
-
-	err = usersAPI.DeleteUser(ctx, user)
-	require.Nil(t, err)
-
-}
-
-func TestUsersAPI(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
-
-	usersAPI := client.UsersAPI()
-
-	me, err := usersAPI.Me(context.Background())
-	require.Nil(t, err)
-	require.NotNil(t, me)
-
-	users, err := usersAPI.GetUsers(context.Background())
-	require.Nil(t, err)
-	require.NotNil(t, users)
-	assert.Len(t, *users, 1)
-
-	user, err := usersAPI.CreateUserWithName(context.Background(), "user-01")
-	require.Nil(t, err)
-	require.NotNil(t, user)
-
-	users, err = usersAPI.GetUsers(context.Background())
-	require.Nil(t, err)
-	require.NotNil(t, users)
-	assert.Len(t, *users, 2)
-
-	status := domain.UserStatusInactive
-	user.Status = &status
-	user, err = usersAPI.UpdateUser(context.Background(), user)
-	require.Nil(t, err)
-	require.NotNil(t, user)
-	assert.Equal(t, status, *user.Status)
-
-	user, err = usersAPI.FindUserByID(context.Background(), *user.Id)
-	require.Nil(t, err)
-	require.NotNil(t, user)
-
-	err = usersAPI.UpdateUserPassword(context.Background(), user, "my-password")
-	require.Nil(t, err)
-
-	err = usersAPI.DeleteUser(context.Background(), user)
-	require.Nil(t, err)
-
-	users, err = usersAPI.GetUsers(context.Background())
-	require.Nil(t, err)
-	require.NotNil(t, users)
-	assert.Len(t, *users, 1)
-}
-
-func TestDeleteAPI(t *testing.T) {
-	ctx := context.Background()
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
-	writeAPI := client.WriteAPIBlocking("my-org", "my-bucket")
-	queryAPI := client.QueryAPI("my-org")
-	tmStart := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-	writeF := func(start time.Time, count int64) time.Time {
-		tm := start
-		for i, f := int64(0), 0.0; i < count; i++ {
-			p := write.NewPoint("test",
-				map[string]string{"a": strconv.FormatInt(i%2, 10), "b": "static"},
-				map[string]interface{}{"f": f, "i": i},
-				tm)
-			err := writeAPI.WritePoint(ctx, p)
-			require.Nil(t, err, err)
-			f += 1.2
-			tm = tm.Add(time.Minute)
-		}
-		return tm
-	}
-	countF := func(start, stop time.Time) int64 {
-		result, err := queryAPI.Query(ctx, `from(bucket:"my-bucket")|> range(start: `+start.Format(time.RFC3339)+`, stop:`+stop.Format(time.RFC3339)+`) 
-		|> filter(fn: (r) => r._measurement == "test" and r._field == "f")
-		|> drop(columns: ["a", "b"])
-		|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
-		|> count(column: "f")`)
-
-		require.Nil(t, err, err)
-		count := int64(0)
-		if result.Next() {
-			require.NotNil(t, result.Record().ValueByKey("f"))
-			count = result.Record().ValueByKey("f").(int64)
-		}
-		return count
-	}
-	tmEnd := writeF(tmStart, 100)
-	assert.Equal(t, int64(100), countF(tmStart, tmEnd))
-	deleteAPI := client.DeleteAPI()
-
-	org, err := client.OrganizationsAPI().FindOrganizationByName(ctx, "my-org")
-	require.Nil(t, err, err)
-	require.NotNil(t, org)
-
-	bucket, err := client.BucketsAPI().FindBucketByName(ctx, "my-bucket")
-	require.Nil(t, err, err)
-	require.NotNil(t, bucket)
-
-	err = deleteAPI.DeleteWithName(ctx, "my-org", "my-bucket", tmStart, tmEnd, "")
-	require.Nil(t, err, err)
-	assert.Equal(t, int64(0), countF(tmStart, tmEnd))
-
-	tmEnd = writeF(tmStart, 100)
-	assert.Equal(t, int64(100), countF(tmStart, tmEnd))
-
-	err = deleteAPI.DeleteWithID(ctx, *org.Id, *bucket.Id, tmStart, tmEnd, "a=1")
-	require.Nil(t, err, err)
-	assert.Equal(t, int64(50), countF(tmStart, tmEnd))
-
-	err = deleteAPI.Delete(ctx, org, bucket, tmStart.Add(50*time.Minute), tmEnd, "b=static")
-	require.Nil(t, err, err)
-	assert.Equal(t, int64(25), countF(tmStart, tmEnd))
-
-	err = deleteAPI.DeleteWithName(ctx, "org", "my-bucket", tmStart.Add(50*time.Minute), tmEnd, "b=static")
-	require.NotNil(t, err, err)
-	assert.True(t, strings.Contains(err.Error(), "not found"))
-
-	err = deleteAPI.DeleteWithName(ctx, "my-org", "bucket", tmStart.Add(50*time.Minute), tmEnd, "b=static")
-	require.NotNil(t, err, err)
-	assert.True(t, strings.Contains(err.Error(), "not found"))
-}
-
-func TestBucketsAPI(t *testing.T) {
-	ctx := context.Background()
-	client := influxdb2.NewClient("http://localhost:9999", authToken)
-
-	bucketsAPI := client.BucketsAPI()
-
-	buckets, err := bucketsAPI.GetBuckets(ctx)
-	require.Nil(t, err, err)
-	require.NotNil(t, buckets)
-	//at least three buckets, my-bucket and two system buckets.
-	assert.True(t, len(*buckets) > 2)
-
-	// test find existing bucket
-	bucket, err := bucketsAPI.FindBucketByName(ctx, "my-bucket")
-	require.Nil(t, err, err)
-	require.NotNil(t, bucket)
-	assert.Equal(t, "my-bucket", bucket.Name)
-
-	//test find non-existing bucket
-	bucket, err = bucketsAPI.FindBucketByName(ctx, "not existing bucket")
-	assert.NotNil(t, err)
-	assert.Nil(t, bucket)
-
-	// create organizatiton for bucket
-	org, err := client.OrganizationsAPI().CreateOrganizationWithName(ctx, "bucket-org")
-	require.Nil(t, err)
-	require.NotNil(t, org)
-
-	// collect all buckets including system ones created for new organization
-	buckets, err = bucketsAPI.GetBuckets(ctx)
-	require.Nil(t, err, err)
-	//store #all buckets before creating new ones
-	bucketsNum := len(*buckets)
-
-	name := "bucket-x"
-	b, err := bucketsAPI.CreateBucketWithName(ctx, org, name, domain.RetentionRule{EverySeconds: 3600 * 1}, domain.RetentionRule{EverySeconds: 3600 * 24})
-	require.Nil(t, err, err)
-	require.NotNil(t, b)
-	assert.Equal(t, name, b.Name)
-	assert.Len(t, b.RetentionRules, 1)
-
-	// Test update
-	desc := "bucket description"
-	b.Description = &desc
-	b.RetentionRules = []domain.RetentionRule{{EverySeconds: 60}}
-	b, err = bucketsAPI.UpdateBucket(ctx, b)
-	require.Nil(t, err, err)
-	require.NotNil(t, b)
-	assert.Equal(t, name, b.Name)
-	assert.Equal(t, desc, *b.Description)
-	assert.Len(t, b.RetentionRules, 1)
-
-	// Test owners
-	userOwner, err := client.UsersAPI().CreateUserWithName(ctx, "bucket-owner")
-	require.Nil(t, err, err)
-	require.NotNil(t, userOwner)
-
-	owners, err := bucketsAPI.GetOwners(ctx, b)
-	require.Nil(t, err, err)
-	require.NotNil(t, owners)
-	assert.Len(t, *owners, 0)
-
-	owner, err := bucketsAPI.AddOwner(ctx, b, userOwner)
-	require.Nil(t, err, err)
-	require.NotNil(t, owner)
-	assert.Equal(t, *userOwner.Id, *owner.Id)
-
-	owners, err = bucketsAPI.GetOwners(ctx, b)
-	require.Nil(t, err, err)
-	require.NotNil(t, owners)
-	assert.Len(t, *owners, 1)
-
-	err = bucketsAPI.RemoveOwnerWithID(ctx, *b.Id, *(&(*owners)[0]).Id)
-	require.Nil(t, err, err)
-
-	owners, err = bucketsAPI.GetOwners(ctx, b)
-	require.Nil(t, err, err)
-	require.NotNil(t, owners)
-	assert.Len(t, *owners, 0)
-
-	//test failures
-	_, err = bucketsAPI.AddOwnerWithID(ctx, "000000000000000", *userOwner.Id)
-	assert.NotNil(t, err)
-
-	_, err = bucketsAPI.AddOwnerWithID(ctx, *b.Id, "000000000000000")
-	assert.NotNil(t, err)
-
-	_, err = bucketsAPI.GetOwnersWithID(ctx, "000000000000000")
-	assert.NotNil(t, err)
-
-	err = bucketsAPI.RemoveOwnerWithID(ctx, *b.Id, "000000000000000")
-	assert.NotNil(t, err)
-
-	err = bucketsAPI.RemoveOwnerWithID(ctx, "000000000000000", *userOwner.Id)
-	assert.NotNil(t, err)
-
-	// Test members
-	userMember, err := client.UsersAPI().CreateUserWithName(ctx, "bucket-member")
-	require.Nil(t, err, err)
-	require.NotNil(t, userMember)
-
-	members, err := bucketsAPI.GetMembers(ctx, b)
-	require.Nil(t, err, err)
-	require.NotNil(t, members)
-	assert.Len(t, *members, 0)
-
-	member, err := bucketsAPI.AddMember(ctx, b, userMember)
-	require.Nil(t, err, err)
-	require.NotNil(t, member)
-	assert.Equal(t, *userMember.Id, *member.Id)
-
-	members, err = bucketsAPI.GetMembers(ctx, b)
-	require.Nil(t, err, err)
-	require.NotNil(t, members)
-	assert.Len(t, *members, 1)
-
-	err = bucketsAPI.RemoveMemberWithID(ctx, *b.Id, *(&(*members)[0]).Id)
-	require.Nil(t, err, err)
-
-	members, err = bucketsAPI.GetMembers(ctx, b)
-	require.Nil(t, err, err)
-	require.NotNil(t, members)
-	assert.Len(t, *members, 0)
-
-	//test failures
-	_, err = bucketsAPI.AddMemberWithID(ctx, "000000000000000", *userMember.Id)
-	assert.NotNil(t, err)
-
-	_, err = bucketsAPI.AddMemberWithID(ctx, *b.Id, "000000000000000")
-	assert.NotNil(t, err)
-
-	_, err = bucketsAPI.GetMembersWithID(ctx, "000000000000000")
-	assert.NotNil(t, err)
-
-	err = bucketsAPI.RemoveMemberWithID(ctx, *b.Id, "000000000000000")
-	assert.NotNil(t, err)
-
-	err = bucketsAPI.RemoveMemberWithID(ctx, "000000000000000", *userMember.Id)
-	assert.NotNil(t, err)
-
-	err = bucketsAPI.DeleteBucketWithID(ctx, *b.Id)
-	assert.Nil(t, err, err)
-
-	err = client.UsersAPI().DeleteUser(ctx, userOwner)
-	assert.Nil(t, err, err)
-
-	err = client.UsersAPI().DeleteUser(ctx, userMember)
-	assert.Nil(t, err, err)
-
-	//test failures
-	_, err = bucketsAPI.FindBucketByID(ctx, *b.Id)
-	assert.NotNil(t, err)
-
-	_, err = bucketsAPI.UpdateBucket(ctx, b)
-	assert.NotNil(t, err)
-
-	b.OrgID = b.Id
-	_, err = bucketsAPI.CreateBucket(ctx, b)
-	assert.NotNil(t, err)
-
-	// create bucket by object
-	b = &domain.Bucket{
-		Description:    &desc,
-		Name:           name,
-		OrgID:          org.Id,
-		RetentionRules: []domain.RetentionRule{{EverySeconds: 3600}},
-	}
-
-	b, err = bucketsAPI.CreateBucket(ctx, b)
-	require.Nil(t, err, err)
-	require.NotNil(t, b)
-	assert.Equal(t, name, b.Name)
-	assert.Equal(t, *org.Id, *b.OrgID)
-	assert.Equal(t, desc, *b.Description)
-	assert.Len(t, b.RetentionRules, 1)
-
-	// fail duplicit name
-	_, err = bucketsAPI.CreateBucketWithName(ctx, org, b.Name)
-	assert.NotNil(t, err)
-
-	// fail org not found
-	_, err = bucketsAPI.CreateBucketWithNameWithID(ctx, *b.Id, b.Name)
-	assert.NotNil(t, err)
-
-	err = bucketsAPI.DeleteBucketWithID(ctx, *b.Id)
-	assert.Nil(t, err, err)
-
-	err = bucketsAPI.DeleteBucketWithID(ctx, *b.Id)
-	assert.NotNil(t, err)
-
-	// create new buckets inside org
-	for i := 0; i < 30; i++ {
-		name := fmt.Sprintf("bucket-%03d", i)
-		b, err := bucketsAPI.CreateBucketWithName(ctx, org, name)
-		require.Nil(t, err, err)
-		require.NotNil(t, b)
-		assert.Equal(t, name, b.Name)
-	}
-
-	// test paging, 1st page
-	buckets, err = bucketsAPI.GetBuckets(ctx)
-	require.Nil(t, err, err)
-	require.NotNil(t, buckets)
-	assert.Len(t, *buckets, 20)
-	// test paging, 2nd, last page
-	buckets, err = bucketsAPI.GetBuckets(ctx, api.PagingWithOffset(20))
-	require.Nil(t, err, err)
-	require.NotNil(t, buckets)
-	//+2 is a bug, when using offset>4 there are returned also system buckets
-	assert.Len(t, *buckets, 10+2+bucketsNum)
-	// test paging with increase limit to cover all buckets
-	buckets, err = bucketsAPI.GetBuckets(ctx, api.PagingWithLimit(100))
-	require.Nil(t, err, err)
-	require.NotNil(t, buckets)
-	assert.Len(t, *buckets, 30+bucketsNum)
-	// test filtering buckets by org id
-	buckets, err = bucketsAPI.FindBucketsByOrgID(ctx, *org.Id, api.PagingWithLimit(100))
-	require.Nil(t, err, err)
-	require.NotNil(t, buckets)
-	assert.Len(t, *buckets, 30+2)
-	// test filtering buckets by org name
-	buckets, err = bucketsAPI.FindBucketsByOrgName(ctx, org.Name, api.PagingWithLimit(100))
-	require.Nil(t, err, err)
-	require.NotNil(t, buckets)
-	assert.Len(t, *buckets, 30+2)
-	// delete buckete
-	for _, b := range *buckets {
-		if strings.HasPrefix(b.Name, "bucket-") {
-			err = bucketsAPI.DeleteBucket(ctx, &b)
-			assert.Nil(t, err, err)
-		}
-	}
-	// check all created buckets deleted
-	buckets, err = bucketsAPI.FindBucketsByOrgName(ctx, org.Name, api.PagingWithLimit(100))
-	require.Nil(t, err, err)
-	require.NotNil(t, buckets)
-	assert.Len(t, *buckets, 2)
-
-	err = client.OrganizationsAPI().DeleteOrganization(ctx, org)
-	assert.Nil(t, err, err)
-
-	// should fail with org not found
-	_, err = bucketsAPI.FindBucketsByOrgName(ctx, org.Name, api.PagingWithLimit(100))
-	assert.NotNil(t, err)
-}
-
-func TestLabelsAPI(t *testing.T) {
-	client := influxdb2.NewClientWithOptions("http://localhost:9999", authToken, influxdb2.DefaultOptions().SetLogLevel(3))
-	labelsAPI := client.LabelsAPI()
-	orgAPI := client.OrganizationsAPI()
-
-	ctx := context.Background()
-
-	myorg, err := orgAPI.FindOrganizationByName(ctx, "my-org")
-	require.Nil(t, err, err)
-	require.NotNil(t, myorg)
-
-	labels, err := labelsAPI.GetLabels(ctx)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 0)
-
-	labelName := "Active State"
-	props := map[string]string{"color": "#33ffddd", "description": "Marks org active"}
-	label, err := labelsAPI.CreateLabelWithName(ctx, myorg, labelName, props)
-	require.Nil(t, err, err)
-	require.NotNil(t, label)
-	assert.Equal(t, labelName, *label.Name)
-	require.NotNil(t, label.Properties)
-	assert.Equal(t, props, label.Properties.AdditionalProperties)
-
-	//remove properties
-	label.Properties.AdditionalProperties = map[string]string{"color": "", "description": ""}
-	label2, err := labelsAPI.UpdateLabel(ctx, label)
-	require.Nil(t, err, err)
-	require.NotNil(t, label2)
-	assert.Equal(t, labelName, *label2.Name)
-	assert.Nil(t, label2.Properties)
-
-	label2, err = labelsAPI.FindLabelByID(ctx, *label.Id)
-	require.Nil(t, err, err)
-	require.NotNil(t, label2)
-	assert.Equal(t, labelName, *label2.Name)
-
-	label2, err = labelsAPI.FindLabelByID(ctx, "000000000000000")
-	require.NotNil(t, err, err)
-	require.Nil(t, label2)
-
-	label2, err = labelsAPI.FindLabelByName(ctx, *myorg.Id, labelName)
-	require.Nil(t, err, err)
-	require.NotNil(t, label2)
-	assert.Equal(t, labelName, *label2.Name)
-
-	label2, err = labelsAPI.FindLabelByName(ctx, *myorg.Id, "wrong label")
-	require.NotNil(t, err, err)
-	require.Nil(t, label2)
-
-	labels, err = labelsAPI.GetLabels(ctx)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 1)
-
-	labels, err = labelsAPI.FindLabelsByOrg(ctx, myorg)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 1)
-
-	labels, err = labelsAPI.FindLabelsByOrgID(ctx, *myorg.Id)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 1)
-
-	labels, err = labelsAPI.FindLabelsByOrgID(ctx, "000000000000000")
-	require.NotNil(t, err, err)
-	require.Nil(t, labels)
-
-	// duplicate label
-	label2, err = labelsAPI.CreateLabelWithName(ctx, myorg, labelName, nil)
-	require.NotNil(t, err, err)
-	require.Nil(t, label2)
-
-	labels, err = orgAPI.GetLabels(ctx, myorg)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 0)
-
-	org, err := orgAPI.CreateOrganizationWithName(ctx, "org1")
-	require.Nil(t, err, err)
-	require.NotNil(t, org)
-
-	labels, err = orgAPI.GetLabels(ctx, org)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 0)
-
-	labelx, err := orgAPI.AddLabel(ctx, org, label)
-	require.Nil(t, err, err)
-	require.NotNil(t, labelx)
-
-	labels, err = orgAPI.GetLabels(ctx, org)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 1)
-
-	err = orgAPI.RemoveLabel(ctx, org, label)
-	require.Nil(t, err, err)
-
-	labels, err = orgAPI.GetLabels(ctx, org)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 0)
-
-	labels, err = orgAPI.GetLabelsWithID(ctx, "000000000000000")
-	require.NotNil(t, err, err)
-	require.Nil(t, labels)
-
-	label2, err = orgAPI.AddLabelWithID(ctx, *org.Id, "000000000000000")
-	require.NotNil(t, err, err)
-	require.Nil(t, label2)
-
-	label2, err = orgAPI.AddLabelWithID(ctx, "000000000000000", "000000000000000")
-	require.NotNil(t, err, err)
-	require.Nil(t, label2)
-
-	err = orgAPI.RemoveLabelWithID(ctx, *org.Id, "000000000000000")
-	require.NotNil(t, err, err)
-	require.Nil(t, label2)
-
-	err = orgAPI.RemoveLabelWithID(ctx, "000000000000000", "000000000000000")
-	require.NotNil(t, err, err)
-	require.Nil(t, label2)
-
-	err = orgAPI.DeleteOrganization(ctx, org)
-	assert.Nil(t, err, err)
-
-	err = labelsAPI.DeleteLabel(ctx, label)
-	require.Nil(t, err, err)
-
-	err = labelsAPI.DeleteLabel(ctx, label)
-	require.NotNil(t, err, err)
 }

--- a/scripts/influxdb-restart.sh
+++ b/scripts/influxdb-restart.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+set -e
+
+DEFAULT_DOCKER_REGISTRY="quay.io/influxdb/"
+DOCKER_REGISTRY="${DOCKER_REGISTRY:-$DEFAULT_DOCKER_REGISTRY}"
+
+DEFAULT_INFLUXDB_V2_REPOSITORY="influxdb"
+DEFAULT_INFLUXDB_V2_VERSION="2.0.0-beta"
+INFLUXDB_V2_REPOSITORY="${INFLUXDB_V2_REPOSITORY:-$DEFAULT_INFLUXDB_V2_REPOSITORY}"
+INFLUXDB_V2_VERSION="${INFLUXDB_V2_VERSION:-$DEFAULT_INFLUXDB_V2_VERSION}"
+INFLUXDB_V2_IMAGE=${DOCKER_REGISTRY}${INFLUXDB_V2_REPOSITORY}:${INFLUXDB_V2_VERSION}
+
+SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+docker kill influxdb_v2 || true
+docker rm influxdb_v2 || true
+docker kill influxdb_v2_onboarding || true
+docker rm influxdb_v2_onboarding || true
+docker network rm influx_network || true
+docker network create -d bridge influx_network --subnet 192.168.0.0/24 --gateway 192.168.0.1
+
+#
+# InfluxDB 2.0
+#
+echo
+echo "Restarting InfluxDB 2.0 [${INFLUXDB_V2_IMAGE}] ... "
+echo
+
+docker pull ${INFLUXDB_V2_IMAGE} || true
+docker run \
+       --detach \
+       --name influxdb_v2 \
+       --network influx_network \
+       --publish 9999:9999 \
+       ${INFLUXDB_V2_IMAGE}
+
+echo "Wait to start InfluxDB 2.0"
+wget -S --spider --tries=20 --retry-connrefused --waitretry=5 http://localhost:9999/metrics
+
+echo
+echo "Post onBoarding request, to setup initial user (my-user@my-password), org (my-org) and bucketSetup (my-bucket)"
+echo
+curl -i -X POST http://localhost:9999/api/v2/setup -H 'accept: application/json' \
+    -d '{
+            "username": "my-user",
+            "password": "my-password",
+            "org": "my-org",
+            "bucket": "my-bucket",
+            "token": "my-token"
+        }'
+
+#
+# InfluxDB 2.0
+#
+echo
+echo "Restarting InfluxDB 2.0 for onboarding test... "
+echo
+
+docker run \
+       --detach \
+       --name influxdb_v2_onboarding \
+       --network influx_network \
+       --publish 9990:9999 \
+       ${INFLUXDB_V2_IMAGE}
+


### PR DESCRIPTION
Split huge E2E test set in `client_e2e_tests.go` to test/file per tested feature. Except for Setup, Ready, Health, Write, and Query.

## Checklist
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

