### PR TITLE
feat: allow overriding the http.Client for the http service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.5.0 [In progress]
+1. [#165](https://github.com/influxdata/influxdb-client-go/pull/165) Allow overriding the http.Client for the http service.
 
 ## 1.4.0 [2020-07-17]
 ### Breaking changes

--- a/api/http/options_test.go
+++ b/api/http/options_test.go
@@ -6,9 +6,12 @@ package http_test
 
 import (
 	"crypto/tls"
+	nethttp "net/http"
+	"testing"
+	"time"
+
 	"github.com/influxdata/influxdb-client-go/api/http"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestDefaultOptions(t *testing.T) {
@@ -26,4 +29,15 @@ func TestOptionsSetting(t *testing.T) {
 		SetHTTPRequestTimeout(50)
 	assert.Equal(t, tlsConfig, opts.TLSConfig())
 	assert.Equal(t, uint(50), opts.HTTPRequestTimeout())
+	if client := opts.HTTPClient(); assert.NotNil(t, client) {
+		assert.Equal(t, 50*time.Second, client.Timeout)
+		assert.Equal(t, tlsConfig, client.Transport.(*nethttp.Transport).TLSClientConfig)
+	}
+
+	client := &nethttp.Client{
+		Transport: &nethttp.Transport{},
+	}
+	opts = http.DefaultOptions()
+	opts.SetHTTPClient(client)
+	assert.Equal(t, client, opts.HTTPClient())
 }

--- a/internal/http/service.go
+++ b/internal/http/service.go
@@ -11,11 +11,9 @@ import (
 	"io"
 	"io/ioutil"
 	"mime"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
-	"time"
 
 	http2 "github.com/influxdata/influxdb-client-go/api/http"
 )
@@ -61,16 +59,7 @@ func NewService(serverURL, authorization string, httpOptions *http2.Options) Ser
 		serverAPIURL:  serverAPIURL,
 		serverURL:     serverURL,
 		authorization: authorization,
-		client: &http.Client{
-			Timeout: time.Second * time.Duration(httpOptions.HTTPRequestTimeout()),
-			Transport: &http.Transport{
-				DialContext: (&net.Dialer{
-					Timeout: 5 * time.Second,
-				}).DialContext,
-				TLSHandshakeTimeout: 5 * time.Second,
-				TLSClientConfig:     httpOptions.TLSConfig(),
-			},
-		},
+		client: httpOptions.HTTPClient(),
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -6,9 +6,11 @@ package influxdb2
 
 import (
 	"crypto/tls"
+	nethttp "net/http"
+	"time"
+
 	"github.com/influxdata/influxdb-client-go/api/http"
 	"github.com/influxdata/influxdb-client-go/api/write"
-	"time"
 )
 
 // Options holds configuration properties for communicating with InfluxDB server
@@ -108,6 +110,24 @@ func (o *Options) UseGZip() bool {
 func (o *Options) SetUseGZip(useGZip bool) *Options {
 	o.WriteOptions().SetUseGZip(useGZip)
 	return o
+}
+
+// HTTPClient returns the http.Client that is configured to be used
+// for HTTP requests. It will return the one that has been set using
+// SetHTTPClient or it will construct a default client using the
+// other configured options.
+func (o *Options) HTTPClient() *nethttp.Client {
+	return o.httpOptions.HTTPClient()
+}
+
+// SetHTTPClient will configure the http.Client that is used
+// for HTTP requests. If set to nil, an HTTPClient will be
+// generated.
+//
+// Setting the HTTPClient will cause the other HTTP options
+// to be ignored.
+func (o *Options) SetHTTPClient(c *nethttp.Client) {
+	o.httpOptions.SetHTTPClient(c)
 }
 
 // TLSConfig returns TLS config

--- a/options_test.go
+++ b/options_test.go
@@ -3,14 +3,15 @@ package influxdb2_test
 import (
 	"context"
 	"crypto/tls"
-	influxdb2 "github.com/influxdata/influxdb-client-go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	influxdb2 "github.com/influxdata/influxdb-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultOptions(t *testing.T) {
@@ -52,8 +53,18 @@ func TestSettingsOptions(t *testing.T) {
 	assert.Equal(t, uint(7), opts.MaxRetries())
 	assert.Equal(t, tlsConfig, opts.TLSConfig())
 	assert.Equal(t, uint(50), opts.HTTPRequestTimeout())
+	if client := opts.HTTPClient(); assert.NotNil(t, client) {
+		assert.Equal(t, 50*time.Second, client.Timeout)
+		assert.Equal(t, tlsConfig, client.Transport.(*http.Transport).TLSClientConfig)
+	}
 	assert.Equal(t, uint(3), opts.LogLevel())
 	assert.Len(t, opts.WriteOptions().DefaultTags(), 1)
+
+	client := &http.Client{
+		Transport: &http.Transport{},
+	}
+	opts.SetHTTPClient(client)
+	assert.Equal(t, client, opts.HTTPClient())
 }
 
 func TestTimeout(t *testing.T) {


### PR DESCRIPTION
This allows overriding the http.Client for the http service. If the
client is overridden, the other options are ignored. This allows further
customization such as modifying the underlying http.Transport or the
`CheckRedirect` function.