### PR TITLE
test(e2e): increase management API coverage via E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       ENV: CI
       GO111MODULE: "on"
       INFLUXDB2_URL: "http://localhost:9999"
+      INFLUXDB_URL: "http://localhost:8086"
       INFLUXDB2_ONBOARDING_URL: "http://localhost:9990"
     steps:
       - checkout

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,4 @@
 # docs: https://github.com/probot/semantic-pull-requests#configuration
 # Always validate the PR title AND all the commits
 titleAndCommits: true
+allowMergeCommits: true

--- a/api/authorizations.go
+++ b/api/authorizations.go
@@ -47,53 +47,30 @@ func NewAuthorizationsAPI(apiClient *domain.ClientWithResponses) AuthorizationsA
 
 func (a *authorizationsAPI) GetAuthorizations(ctx context.Context) (*[]domain.Authorization, error) {
 	authQuery := &domain.GetAuthorizationsParams{}
-	auths, err := a.listAuthorizations(ctx, authQuery)
-	if err != nil {
-		return nil, err
-	}
-	return auths.Authorizations, nil
+	return a.listAuthorizations(ctx, authQuery)
 }
 
 func (a *authorizationsAPI) FindAuthorizationsByUserName(ctx context.Context, userName string) (*[]domain.Authorization, error) {
 	authQuery := &domain.GetAuthorizationsParams{User: &userName}
-	auths, err := a.listAuthorizations(ctx, authQuery)
-	if err != nil {
-		return nil, err
-	}
-	return auths.Authorizations, nil
+	return a.listAuthorizations(ctx, authQuery)
 }
 
 func (a *authorizationsAPI) FindAuthorizationsByUserID(ctx context.Context, userID string) (*[]domain.Authorization, error) {
 	authQuery := &domain.GetAuthorizationsParams{UserID: &userID}
-	auths, err := a.listAuthorizations(ctx, authQuery)
-	if err != nil {
-		return nil, err
-	}
-	return auths.Authorizations, nil
+	return a.listAuthorizations(ctx, authQuery)
 }
 
 func (a *authorizationsAPI) FindAuthorizationsByOrgName(ctx context.Context, orgName string) (*[]domain.Authorization, error) {
 	authQuery := &domain.GetAuthorizationsParams{Org: &orgName}
-	auths, err := a.listAuthorizations(ctx, authQuery)
-	if err != nil {
-		return nil, err
-	}
-	return auths.Authorizations, nil
+	return a.listAuthorizations(ctx, authQuery)
 }
 
 func (a *authorizationsAPI) FindAuthorizationsByOrgID(ctx context.Context, orgID string) (*[]domain.Authorization, error) {
 	authQuery := &domain.GetAuthorizationsParams{OrgID: &orgID}
-	auths, err := a.listAuthorizations(ctx, authQuery)
-	if err != nil {
-		return nil, err
-	}
-	return auths.Authorizations, nil
+	return a.listAuthorizations(ctx, authQuery)
 }
 
-func (a *authorizationsAPI) listAuthorizations(ctx context.Context, query *domain.GetAuthorizationsParams) (*domain.Authorizations, error) {
-	if query == nil {
-		query = &domain.GetAuthorizationsParams{}
-	}
+func (a *authorizationsAPI) listAuthorizations(ctx context.Context, query *domain.GetAuthorizationsParams) (*[]domain.Authorization, error) {
 	response, err := a.apiClient.GetAuthorizationsWithResponse(ctx, query)
 	if err != nil {
 		return nil, err
@@ -101,7 +78,7 @@ func (a *authorizationsAPI) listAuthorizations(ctx context.Context, query *domai
 	if response.JSONDefault != nil {
 		return nil, domain.DomainErrorToError(response.JSONDefault, response.StatusCode())
 	}
-	return response.JSON200, nil
+	return response.JSON200.Authorizations, nil
 }
 
 func (a *authorizationsAPI) CreateAuthorization(ctx context.Context, authorization *domain.Authorization) (*domain.Authorization, error) {

--- a/api/buckets.go
+++ b/api/buckets.go
@@ -133,29 +133,9 @@ func (b *bucketsAPI) FindBucketsByOrgName(ctx context.Context, orgName string, p
 	return b.getBuckets(ctx, params, pagingOptions...)
 }
 
-func (b *bucketsAPI) CreateBucket(ctx context.Context, bucket *domain.Bucket) (*domain.Bucket, error) {
+func (b *bucketsAPI) createBucket(ctx context.Context, bucketReq *domain.PostBucketRequest) (*domain.Bucket, error) {
 	params := &domain.PostBucketsParams{}
-	bucketReq := &domain.PostBucketRequest{
-		Description:    bucket.Description,
-		Name:           bucket.Name,
-		OrgID:          bucket.OrgID,
-		RetentionRules: bucket.RetentionRules,
-		Rp:             bucket.Rp,
-	}
 	response, err := b.apiClient.PostBucketsWithResponse(ctx, params, domain.PostBucketsJSONRequestBody(*bucketReq))
-	if err != nil {
-		return nil, err
-	}
-	if response.JSONDefault != nil {
-		return nil, domain.DomainErrorToError(response.JSONDefault, response.StatusCode())
-	}
-	return response.JSON201, nil
-}
-
-func (b *bucketsAPI) CreateBucketWithNameWithID(ctx context.Context, orgID, bucketName string, rules ...domain.RetentionRule) (*domain.Bucket, error) {
-	params := &domain.PostBucketsParams{}
-	bucket := &domain.PostBucketRequest{Name: bucketName, OrgID: &orgID, RetentionRules: rules}
-	response, err := b.apiClient.PostBucketsWithResponse(ctx, params, domain.PostBucketsJSONRequestBody(*bucket))
 	if err != nil {
 		return nil, err
 	}
@@ -166,6 +146,22 @@ func (b *bucketsAPI) CreateBucketWithNameWithID(ctx context.Context, orgID, buck
 		return nil, domain.DomainErrorToError(response.JSONDefault, response.StatusCode())
 	}
 	return response.JSON201, nil
+}
+
+func (b *bucketsAPI) CreateBucket(ctx context.Context, bucket *domain.Bucket) (*domain.Bucket, error) {
+	bucketReq := &domain.PostBucketRequest{
+		Description:    bucket.Description,
+		Name:           bucket.Name,
+		OrgID:          bucket.OrgID,
+		RetentionRules: bucket.RetentionRules,
+		Rp:             bucket.Rp,
+	}
+	return b.createBucket(ctx, bucketReq)
+}
+
+func (b *bucketsAPI) CreateBucketWithNameWithID(ctx context.Context, orgID, bucketName string, rules ...domain.RetentionRule) (*domain.Bucket, error) {
+	bucket := &domain.PostBucketRequest{Name: bucketName, OrgID: &orgID, RetentionRules: rules}
+	return b.createBucket(ctx, bucket)
 }
 func (b *bucketsAPI) CreateBucketWithName(ctx context.Context, org *domain.Organization, bucketName string, rules ...domain.RetentionRule) (*domain.Bucket, error) {
 	return b.CreateBucketWithNameWithID(ctx, *org.Id, bucketName, rules...)

--- a/api/paging_test.go
+++ b/api/paging_test.go
@@ -20,4 +20,12 @@ func TestPaging(t *testing.T) {
 	assert.Equal(t, domain.Limit(100), paging.limit)
 	assert.Equal(t, domain.Offset(10), paging.offset)
 	assert.Equal(t, "name", paging.sortBy)
+
+	paging = &Paging{}
+	PagingWithLimit(0)(paging)
+	assert.Equal(t, domain.Limit(1), paging.limit)
+
+	paging = &Paging{}
+	PagingWithLimit(1000)(paging)
+	assert.Equal(t, domain.Limit(100), paging.limit)
 }

--- a/api/users_e2e_test.go
+++ b/api/users_e2e_test.go
@@ -18,46 +18,124 @@ import (
 
 func TestUsersAPI(t *testing.T) {
 	client := influxdb2.NewClient(serverURL, authToken)
-
 	usersAPI := client.UsersAPI()
+	ctx := context.Background()
 
-	me, err := usersAPI.Me(context.Background())
+	me, err := usersAPI.Me(ctx)
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
-	users, err := usersAPI.GetUsers(context.Background())
+	users, err := usersAPI.GetUsers(ctx)
 	require.Nil(t, err)
 	require.NotNil(t, users)
 	assert.Len(t, *users, 1)
 
-	user, err := usersAPI.CreateUserWithName(context.Background(), "user-01")
+	user, err := usersAPI.CreateUserWithName(ctx, "user-01")
 	require.Nil(t, err)
 	require.NotNil(t, user)
 
-	users, err = usersAPI.GetUsers(context.Background())
+	// create duplicate user
+	user2, err := usersAPI.CreateUserWithName(ctx, "user-01")
+	assert.NotNil(t, err)
+	assert.Nil(t, user2)
+
+	users, err = usersAPI.GetUsers(ctx)
 	require.Nil(t, err)
 	require.NotNil(t, users)
 	assert.Len(t, *users, 2)
 
 	status := domain.UserStatusInactive
 	user.Status = &status
-	user, err = usersAPI.UpdateUser(context.Background(), user)
+	user, err = usersAPI.UpdateUser(ctx, user)
 	require.Nil(t, err)
 	require.NotNil(t, user)
 	assert.Equal(t, status, *user.Status)
 
-	user, err = usersAPI.FindUserByID(context.Background(), *user.Id)
+	user2 = &domain.User{
+		Id:   user.Id,
+		Name: "my-user",
+	}
+	//update username to existing user
+	user2, err = usersAPI.UpdateUser(ctx, user2)
+	assert.NotNil(t, err)
+	assert.Nil(t, user2)
+
+	user, err = usersAPI.FindUserByID(ctx, *user.Id)
 	require.Nil(t, err)
 	require.NotNil(t, user)
 
-	err = usersAPI.UpdateUserPassword(context.Background(), user, "my-password")
+	err = usersAPI.UpdateUserPassword(ctx, user, "my-password")
 	require.Nil(t, err)
 
-	err = usersAPI.DeleteUser(context.Background(), user)
+	err = usersAPI.DeleteUser(ctx, user)
 	require.Nil(t, err)
 
-	users, err = usersAPI.GetUsers(context.Background())
+	users, err = usersAPI.GetUsers(ctx)
 	require.Nil(t, err)
 	require.NotNil(t, users)
 	assert.Len(t, *users, 1)
+
+	// this fails now
+	err = usersAPI.MeUpdatePassword(ctx, "new-password")
+	assert.NotNil(t, err)
+}
+
+func TestUsersAPI_failing(t *testing.T) {
+	client := influxdb2.NewClient(serverURL, authToken)
+	usersAPI := client.UsersAPI()
+	ctx := context.Background()
+
+	invalidID := "aaaaaa"
+
+	user, err := usersAPI.FindUserByID(ctx, invalidID)
+	assert.NotNil(t, err)
+	assert.Nil(t, user)
+
+	user, err = usersAPI.FindUserByName(ctx, "not-existing-name")
+	assert.NotNil(t, err)
+	assert.Nil(t, user)
+
+	err = usersAPI.DeleteUserWithID(ctx, invalidID)
+	assert.NotNil(t, err)
+
+	err = usersAPI.UpdateUserPasswordWithID(ctx, invalidID, "pass")
+	assert.NotNil(t, err)
+}
+
+func TestUsersAPI_requestFailing(t *testing.T) {
+	client := influxdb2.NewClient("serverURL", authToken)
+	usersAPI := client.UsersAPI()
+	ctx := context.Background()
+
+	invalidID := "aaaaaa"
+
+	user := &domain.User{
+		Id: &invalidID,
+	}
+	_, err := usersAPI.GetUsers(ctx)
+	assert.NotNil(t, err)
+
+	_, err = usersAPI.FindUserByID(ctx, invalidID)
+	assert.NotNil(t, err)
+
+	_, err = usersAPI.FindUserByName(ctx, "not-existing-name")
+	assert.NotNil(t, err)
+
+	_, err = usersAPI.CreateUserWithName(ctx, "not-existing-name")
+	assert.NotNil(t, err)
+
+	_, err = usersAPI.UpdateUser(ctx, user)
+	assert.NotNil(t, err)
+
+	err = usersAPI.UpdateUserPasswordWithID(ctx, invalidID, "pass")
+	assert.NotNil(t, err)
+
+	err = usersAPI.DeleteUserWithID(ctx, invalidID)
+	assert.NotNil(t, err)
+
+	_, err = usersAPI.Me(ctx)
+	assert.NotNil(t, err)
+
+	err = usersAPI.MeUpdatePassword(ctx, "pass")
+	assert.NotNil(t, err)
 }

--- a/scripts/influxdb.conf
+++ b/scripts/influxdb.conf
@@ -1,0 +1,43 @@
+#
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+
+[meta]
+  dir = "/var/lib/influxdb/meta"
+
+[data]
+  dir = "/var/lib/influxdb/data"
+  engine = "tsm1"
+  wal-dir = "/var/lib/influxdb/wal"
+
+
+[http]
+  flux-enabled = true
+
+# These next lines control how batching works. You should have this enabled
+# otherwise you could get dropped metrics or poor performance. Batching
+# will buffer points in memory if you have many coming in.
+
+batch-size = 1000 # will flush if this many points get buffered
+batch-pending = 5 # number of batches that may be pending in memory
+batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
+read-buffer = 0 # UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.


### PR DESCRIPTION
- Increased test coverage of management APIs via extending E2E tests
- Added E2E testing of InfluxDB 1.8.1 forward compatibility APIs

## Checklist
- [X] Rebased/mergeable
- [X] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)