### PR TITLE
chore(API): Sync with the beta 16 swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.5.0 [In progress]
+### Breaking changes
+1. [#173](https://github.com/influxdata/influxdb-client-go/pull/173) Removed orgs labels API cause [it has been removed from the server API](https://github.com/influxdata/influxdb/pull/19104)
+
+### Features
 1. [#165](https://github.com/influxdata/influxdb-client-go/pull/165) Allow overriding the http.Client for the http service.
 
 ## 1.4.0 [2020-07-17]

--- a/api/buckets.go
+++ b/api/buckets.go
@@ -152,7 +152,7 @@ func (b *bucketsAPI) CreateBucket(ctx context.Context, bucket *domain.Bucket) (*
 	bucketReq := &domain.PostBucketRequest{
 		Description:    bucket.Description,
 		Name:           bucket.Name,
-		OrgID:          bucket.OrgID,
+		OrgID:          *bucket.OrgID,
 		RetentionRules: bucket.RetentionRules,
 		Rp:             bucket.Rp,
 	}
@@ -160,7 +160,7 @@ func (b *bucketsAPI) CreateBucket(ctx context.Context, bucket *domain.Bucket) (*
 }
 
 func (b *bucketsAPI) CreateBucketWithNameWithID(ctx context.Context, orgID, bucketName string, rules ...domain.RetentionRule) (*domain.Bucket, error) {
-	bucket := &domain.PostBucketRequest{Name: bucketName, OrgID: &orgID, RetentionRules: rules}
+	bucket := &domain.PostBucketRequest{Name: bucketName, OrgID: orgID, RetentionRules: rules}
 	return b.createBucket(ctx, bucket)
 }
 func (b *bucketsAPI) CreateBucketWithName(ctx context.Context, org *domain.Organization, bucketName string, rules ...domain.RetentionRule) (*domain.Bucket, error) {

--- a/api/buckets_e2e_test.go
+++ b/api/buckets_e2e_test.go
@@ -199,8 +199,7 @@ func TestBucketsAPI(t *testing.T) {
 	buckets, err = bucketsAPI.GetBuckets(ctx, api.PagingWithOffset(20))
 	require.Nil(t, err, err)
 	require.NotNil(t, buckets)
-	//+2 is a bug, when using offset>4 there are returned also system buckets
-	assert.Len(t, *buckets, 10+2+bucketsNum)
+	assert.Len(t, *buckets, 10+bucketsNum)
 	// test paging with increase limit to cover all buckets
 	buckets, err = bucketsAPI.GetBuckets(ctx, api.PagingWithLimit(100))
 	require.Nil(t, err, err)
@@ -210,11 +209,13 @@ func TestBucketsAPI(t *testing.T) {
 	buckets, err = bucketsAPI.FindBucketsByOrgID(ctx, *org.Id, api.PagingWithLimit(100))
 	require.Nil(t, err, err)
 	require.NotNil(t, buckets)
+	////+2 for system buckets
 	assert.Len(t, *buckets, 30+2)
 	// test filtering buckets by org name
 	buckets, err = bucketsAPI.FindBucketsByOrgName(ctx, org.Name, api.PagingWithLimit(100))
 	require.Nil(t, err, err)
 	require.NotNil(t, buckets)
+	////+2 for system buckets
 	assert.Len(t, *buckets, 30+2)
 	// delete buckete
 	for _, b := range *buckets {
@@ -290,7 +291,7 @@ func TestBucketsAPI_requestFailing(t *testing.T) {
 	bucketsAPI := client.BucketsAPI()
 
 	anID := "1000000000000000"
-	bucket := &domain.Bucket{Id: &anID}
+	bucket := &domain.Bucket{Id: &anID, OrgID: &anID}
 	user := &domain.User{Id: &anID}
 
 	_, err := bucketsAPI.GetBuckets(ctx)

--- a/api/examples_test.go
+++ b/api/examples_test.go
@@ -347,18 +347,6 @@ func ExampleLabelsAPI() {
 		panic(err)
 	}
 
-	// Get organization that will have the label
-	org, err := orgsAPI.FindOrganizationByName(ctx, "IT")
-	if err != nil {
-		panic(err)
-	}
-
-	// Add label to org
-	_, err = orgsAPI.AddLabel(ctx, org, label)
-	if err != nil {
-		panic(err)
-	}
-
 	// Change color property
 	label.Properties.AdditionalProperties = map[string]string{"color": "ff1122"}
 	label, err = labelsAPI.UpdateLabel(ctx, label)

--- a/api/labels_e2e_test.go
+++ b/api/labels_e2e_test.go
@@ -83,40 +83,6 @@ func TestLabelsAPI(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Nil(t, label2)
 
-	labels, err = orgAPI.GetLabels(ctx, myorg)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 0)
-
-	org, err := orgAPI.CreateOrganizationWithName(ctx, "org1")
-	require.Nil(t, err, err)
-	require.NotNil(t, org)
-
-	labels, err = orgAPI.GetLabels(ctx, org)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 0)
-
-	labelx, err := orgAPI.AddLabel(ctx, org, label)
-	require.Nil(t, err, err)
-	require.NotNil(t, labelx)
-
-	labels, err = orgAPI.GetLabels(ctx, org)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 1)
-
-	err = orgAPI.RemoveLabel(ctx, org, label)
-	require.Nil(t, err, err)
-
-	labels, err = orgAPI.GetLabels(ctx, org)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 0)
-
-	err = orgAPI.DeleteOrganization(ctx, org)
-	assert.Nil(t, err, err)
-
 	err = labelsAPI.DeleteLabel(ctx, label)
 	require.Nil(t, err, err)
 	//
@@ -155,26 +121,6 @@ func TestLabelsAPI_failing(t *testing.T) {
 
 	err = labelsAPI.DeleteLabelWithID(ctx, invalidID)
 	assert.NotNil(t, err)
-
-	labels, err = orgAPI.GetLabelsWithID(ctx, wrongID)
-	assert.NotNil(t, err)
-	assert.Nil(t, labels)
-
-	label, err = orgAPI.AddLabelWithID(ctx, *org.Id, wrongID)
-	assert.NotNil(t, err)
-	assert.Nil(t, label)
-
-	label, err = orgAPI.AddLabelWithID(ctx, wrongID, wrongID)
-	assert.NotNil(t, err)
-	assert.Nil(t, label)
-
-	err = orgAPI.RemoveLabelWithID(ctx, *org.Id, invalidID)
-	assert.NotNil(t, err)
-	assert.Nil(t, label)
-
-	err = orgAPI.RemoveLabelWithID(ctx, invalidID, invalidID)
-	assert.NotNil(t, err, err)
-	assert.Nil(t, label)
 }
 
 func TestLabelsAPI_requestFailing(t *testing.T) {

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -54,18 +54,6 @@ type OrganizationsAPI interface {
 	RemoveOwner(ctx context.Context, org *domain.Organization, user *domain.User) error
 	// RemoveOwnerWithID removes an owner with id memberID from an organization with orgID.
 	RemoveOwnerWithID(ctx context.Context, orgID, memberID string) error
-	// GetLabels returns labels of an organization.
-	GetLabels(ctx context.Context, org *domain.Organization) (*[]domain.Label, error)
-	// GetLabelsWithID returns labels of an organization with orgID.
-	GetLabelsWithID(ctx context.Context, orgID string) (*[]domain.Label, error)
-	// AddLabel adds a label to an organization.
-	AddLabel(ctx context.Context, org *domain.Organization, label *domain.Label) (*domain.Label, error)
-	// AddLabelWithID adds a label with id labelID to an organization with orgID.
-	AddLabelWithID(ctx context.Context, orgID, labelID string) (*domain.Label, error)
-	// RemoveLabel removes an label from an organization.
-	RemoveLabel(ctx context.Context, org *domain.Organization, label *domain.Label) error
-	// RemoveLabelWithID removes an label with id labelID from an organization with orgID.
-	RemoveLabelWithID(ctx context.Context, orgID, labelID string) error
 }
 
 type organizationsAPI struct {
@@ -274,55 +262,6 @@ func (o *organizationsAPI) RemoveOwner(ctx context.Context, org *domain.Organiza
 func (o *organizationsAPI) RemoveOwnerWithID(ctx context.Context, orgID, memberID string) error {
 	params := &domain.DeleteOrgsIDOwnersIDParams{}
 	response, err := o.apiClient.DeleteOrgsIDOwnersIDWithResponse(ctx, orgID, memberID, params)
-	if err != nil {
-		return err
-	}
-	if response.JSONDefault != nil {
-		return domain.DomainErrorToError(response.JSONDefault, response.StatusCode())
-	}
-	return nil
-}
-
-func (o *organizationsAPI) GetLabels(ctx context.Context, org *domain.Organization) (*[]domain.Label, error) {
-	return o.GetLabelsWithID(ctx, *org.Id)
-}
-
-func (o *organizationsAPI) GetLabelsWithID(ctx context.Context, orgID string) (*[]domain.Label, error) {
-	params := &domain.GetOrgsIDLabelsParams{}
-	response, err := o.apiClient.GetOrgsIDLabelsWithResponse(ctx, orgID, params)
-	if err != nil {
-		return nil, err
-	}
-	if response.JSONDefault != nil {
-		return nil, domain.DomainErrorToError(response.JSONDefault, response.StatusCode())
-	}
-	return (*[]domain.Label)(response.JSON200.Labels), nil
-}
-
-func (o *organizationsAPI) AddLabel(ctx context.Context, org *domain.Organization, label *domain.Label) (*domain.Label, error) {
-	return o.AddLabelWithID(ctx, *org.Id, *label.Id)
-}
-
-func (o *organizationsAPI) AddLabelWithID(ctx context.Context, orgID, labelID string) (*domain.Label, error) {
-	params := &domain.PostOrgsIDLabelsParams{}
-	body := &domain.PostOrgsIDLabelsJSONRequestBody{LabelID: &labelID}
-	response, err := o.apiClient.PostOrgsIDLabelsWithResponse(ctx, orgID, params, *body)
-	if err != nil {
-		return nil, err
-	}
-	if response.JSONDefault != nil {
-		return nil, domain.DomainErrorToError(response.JSONDefault, response.StatusCode())
-	}
-	return response.JSON201.Label, nil
-}
-
-func (o *organizationsAPI) RemoveLabel(ctx context.Context, org *domain.Organization, label *domain.Label) error {
-	return o.RemoveLabelWithID(ctx, *org.Id, *label.Id)
-}
-
-func (o *organizationsAPI) RemoveLabelWithID(ctx context.Context, orgID, memberID string) error {
-	params := &domain.DeleteOrgsIDLabelsIDParams{}
-	response, err := o.apiClient.DeleteOrgsIDLabelsIDWithResponse(ctx, orgID, memberID, params)
 	if err != nil {
 		return err
 	}

--- a/api/organizations_deprecated.go
+++ b/api/organizations_deprecated.go
@@ -56,18 +56,6 @@ type OrganizationsApi interface {
 	RemoveOwner(ctx context.Context, org *domain.Organization, user *domain.User) error
 	// RemoveOwnerWithId removes an owner with id memberId from an organization with orgId.
 	RemoveOwnerWithId(ctx context.Context, orgId, memberId string) error
-	// GetLabels returns labels of an organization.
-	GetLabels(ctx context.Context, org *domain.Organization) (*[]domain.Label, error)
-	// GetLabelsWithId returns labels of an organization with orgId.
-	GetLabelsWithId(ctx context.Context, orgId string) (*[]domain.Label, error)
-	// AddLabel adds a label to an organization.
-	AddLabel(ctx context.Context, org *domain.Organization, label *domain.Label) (*domain.Label, error)
-	// AddLabelWithId adds a label with id labelId to an organization with orgId.
-	AddLabelWithId(ctx context.Context, orgId, labelId string) (*domain.Label, error)
-	// RemoveLabel removes an label from an organization.
-	RemoveLabel(ctx context.Context, org *domain.Organization, label *domain.Label) error
-	// RemoveLabelWithId removes an label with id labelId from an organization with orgId.
-	RemoveLabelWithId(ctx context.Context, orgId, labelId string) error
 }
 
 type organizationsApiImpl struct {
@@ -164,28 +152,4 @@ func (o *organizationsApiImpl) RemoveOwner(ctx context.Context, org *domain.Orga
 
 func (o *organizationsApiImpl) RemoveOwnerWithId(ctx context.Context, orgId, memberId string) error {
 	return o.organizationsAPI.RemoveMemberWithID(ctx, orgId, memberId)
-}
-
-func (o *organizationsApiImpl) GetLabels(ctx context.Context, org *domain.Organization) (*[]domain.Label, error) {
-	return o.organizationsAPI.GetLabels(ctx, org)
-}
-
-func (o *organizationsApiImpl) GetLabelsWithId(ctx context.Context, orgId string) (*[]domain.Label, error) {
-	return o.organizationsAPI.GetLabelsWithID(ctx, orgId)
-}
-
-func (o *organizationsApiImpl) AddLabel(ctx context.Context, org *domain.Organization, label *domain.Label) (*domain.Label, error) {
-	return o.organizationsAPI.AddLabel(ctx, org, label)
-}
-
-func (o *organizationsApiImpl) AddLabelWithId(ctx context.Context, orgId, labelId string) (*domain.Label, error) {
-	return o.organizationsAPI.AddLabelWithID(ctx, orgId, labelId)
-}
-
-func (o *organizationsApiImpl) RemoveLabel(ctx context.Context, org *domain.Organization, label *domain.Label) error {
-	return o.organizationsAPI.RemoveLabel(ctx, org, label)
-}
-
-func (o *organizationsApiImpl) RemoveLabelWithId(ctx context.Context, orgId, memberId string) error {
-	return o.organizationsAPI.RemoveLabelWithID(ctx, orgId, memberId)
 }

--- a/api/organizations_e2e_test.go
+++ b/api/organizations_e2e_test.go
@@ -325,11 +325,4 @@ func TestOrganizationAPI_requestFailing(t *testing.T) {
 
 	_, err = orgsAPI.GetOwnersWithID(ctx, invalidID)
 	assert.NotNil(t, err)
-
-	_, err = orgsAPI.AddLabelWithID(ctx, *org.Id, anID)
-	assert.NotNil(t, err)
-
-	// remove owner with invalid ID
-	err = orgsAPI.RemoveLabelWithID(ctx, anID, anID)
-	assert.NotNil(t, err)
 }

--- a/client.go
+++ b/client.go
@@ -180,7 +180,7 @@ func (c *clientImpl) Setup(ctx context.Context, username, password, org, bucket 
 	body := &domain.PostSetupJSONRequestBody{
 		Bucket:             bucket,
 		Org:                org,
-		Password:           password,
+		Password:           &password,
 		RetentionPeriodHrs: &retentionPeriodHours,
 		Username:           username,
 	}

--- a/client_e2e_deprecated_test.go
+++ b/client_e2e_deprecated_test.go
@@ -714,8 +714,7 @@ func TestBuckets(t *testing.T) {
 	buckets, err = bucketsAPI.GetBuckets(ctx, api.PagingWithOffset(20))
 	require.Nil(t, err, err)
 	require.NotNil(t, buckets)
-	//+2 is a bug, when using offset>4 there are returned also system buckets
-	assert.Len(t, *buckets, 10+2+bucketsNum)
+	assert.Len(t, *buckets, 10+bucketsNum)
 	// test paging with increase limit to cover all buckets
 	buckets, err = bucketsAPI.GetBuckets(ctx, api.PagingWithLimit(100))
 	require.Nil(t, err, err)
@@ -826,60 +825,6 @@ func TestLabels(t *testing.T) {
 	label2, err = labelsAPI.CreateLabelWithName(ctx, myorg, labelName, nil)
 	require.NotNil(t, err, err)
 	require.Nil(t, label2)
-
-	labels, err = orgAPI.GetLabels(ctx, myorg)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 0)
-
-	org, err := orgAPI.CreateOrganizationWithName(ctx, "org1")
-	require.Nil(t, err, err)
-	require.NotNil(t, org)
-
-	labels, err = orgAPI.GetLabels(ctx, org)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 0)
-
-	labelx, err := orgAPI.AddLabel(ctx, org, label)
-	require.Nil(t, err, err)
-	require.NotNil(t, labelx)
-
-	labels, err = orgAPI.GetLabels(ctx, org)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 1)
-
-	err = orgAPI.RemoveLabel(ctx, org, label)
-	require.Nil(t, err, err)
-
-	labels, err = orgAPI.GetLabels(ctx, org)
-	require.Nil(t, err, err)
-	require.NotNil(t, labels)
-	assert.Len(t, *labels, 0)
-
-	labels, err = orgAPI.GetLabelsWithId(ctx, "000000000000000")
-	require.NotNil(t, err, err)
-	require.Nil(t, labels)
-
-	label2, err = orgAPI.AddLabelWithId(ctx, *org.Id, "000000000000000")
-	require.NotNil(t, err, err)
-	require.Nil(t, label2)
-
-	label2, err = orgAPI.AddLabelWithId(ctx, "000000000000000", "000000000000000")
-	require.NotNil(t, err, err)
-	require.Nil(t, label2)
-
-	err = orgAPI.RemoveLabelWithId(ctx, *org.Id, "000000000000000")
-	require.NotNil(t, err, err)
-	require.Nil(t, label2)
-
-	err = orgAPI.RemoveLabelWithId(ctx, "000000000000000", "000000000000000")
-	require.NotNil(t, err, err)
-	require.Nil(t, label2)
-
-	err = orgAPI.DeleteOrganization(ctx, org)
-	assert.Nil(t, err, err)
 
 	err = labelsAPI.DeleteLabel(ctx, label)
 	require.Nil(t, err, err)

--- a/domain/client.gen.go
+++ b/domain/client.gen.go
@@ -404,28 +404,6 @@ type ClientInterface interface {
 
 	PatchOrgsID(ctx context.Context, orgID string, params *PatchOrgsIDParams, body PatchOrgsIDJSONRequestBody) (*http.Response, error)
 
-	// PostOrgsIDInvites request  with any body
-	PostOrgsIDInvitesWithBody(ctx context.Context, orgID string, params *PostOrgsIDInvitesParams, contentType string, body io.Reader) (*http.Response, error)
-
-	PostOrgsIDInvites(ctx context.Context, orgID string, params *PostOrgsIDInvitesParams, body PostOrgsIDInvitesJSONRequestBody) (*http.Response, error)
-
-	// DeleteOrgsIDInviteID request
-	DeleteOrgsIDInviteID(ctx context.Context, orgID string, inviteID string, params *DeleteOrgsIDInviteIDParams) (*http.Response, error)
-
-	// PostOrgsIDInviteID request
-	PostOrgsIDInviteID(ctx context.Context, orgID string, inviteID string, params *PostOrgsIDInviteIDParams) (*http.Response, error)
-
-	// GetOrgsIDLabels request
-	GetOrgsIDLabels(ctx context.Context, orgID string, params *GetOrgsIDLabelsParams) (*http.Response, error)
-
-	// PostOrgsIDLabels request  with any body
-	PostOrgsIDLabelsWithBody(ctx context.Context, orgID string, params *PostOrgsIDLabelsParams, contentType string, body io.Reader) (*http.Response, error)
-
-	PostOrgsIDLabels(ctx context.Context, orgID string, params *PostOrgsIDLabelsParams, body PostOrgsIDLabelsJSONRequestBody) (*http.Response, error)
-
-	// DeleteOrgsIDLabelsID request
-	DeleteOrgsIDLabelsID(ctx context.Context, orgID string, labelID string, params *DeleteOrgsIDLabelsIDParams) (*http.Response, error)
-
 	// GetOrgsIDMembers request
 	GetOrgsIDMembers(ctx context.Context, orgID string, params *GetOrgsIDMembersParams) (*http.Response, error)
 
@@ -460,44 +438,6 @@ type ClientInterface interface {
 	PostOrgsIDSecretsWithBody(ctx context.Context, orgID string, params *PostOrgsIDSecretsParams, contentType string, body io.Reader) (*http.Response, error)
 
 	PostOrgsIDSecrets(ctx context.Context, orgID string, params *PostOrgsIDSecretsParams, body PostOrgsIDSecretsJSONRequestBody) (*http.Response, error)
-
-	// GetCloudUsers request
-	GetCloudUsers(ctx context.Context, orgID string, params *GetCloudUsersParams) (*http.Response, error)
-
-	// DeleteOrgsIDCloudUserID request
-	DeleteOrgsIDCloudUserID(ctx context.Context, orgID string, userID string, params *DeleteOrgsIDCloudUserIDParams) (*http.Response, error)
-
-	// CreatePkg request  with any body
-	CreatePkgWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
-
-	CreatePkg(ctx context.Context, body CreatePkgJSONRequestBody) (*http.Response, error)
-
-	// ApplyPkg request  with any body
-	ApplyPkgWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
-
-	ApplyPkg(ctx context.Context, body ApplyPkgJSONRequestBody) (*http.Response, error)
-
-	// ListStacks request
-	ListStacks(ctx context.Context, params *ListStacksParams) (*http.Response, error)
-
-	// CreateStack request  with any body
-	CreateStackWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
-
-	CreateStack(ctx context.Context, body CreateStackJSONRequestBody) (*http.Response, error)
-
-	// DeleteStack request
-	DeleteStack(ctx context.Context, stackId string, params *DeleteStackParams) (*http.Response, error)
-
-	// ReadStack request
-	ReadStack(ctx context.Context, stackId string) (*http.Response, error)
-
-	// UpdateStack request  with any body
-	UpdateStackWithBody(ctx context.Context, stackId string, contentType string, body io.Reader) (*http.Response, error)
-
-	UpdateStack(ctx context.Context, stackId string, body UpdateStackJSONRequestBody) (*http.Response, error)
-
-	// ExportStack request
-	ExportStack(ctx context.Context, stackId string, params *ExportStackParams) (*http.Response, error)
 
 	// PostQuery request  with any body
 	PostQueryWithBody(ctx context.Context, params *PostQueryParams, contentType string, body io.Reader) (*http.Response, error)
@@ -623,6 +563,28 @@ type ClientInterface interface {
 
 	// GetSourcesIDHealth request
 	GetSourcesIDHealth(ctx context.Context, sourceID string, params *GetSourcesIDHealthParams) (*http.Response, error)
+
+	// ListStacks request
+	ListStacks(ctx context.Context, params *ListStacksParams) (*http.Response, error)
+
+	// CreateStack request  with any body
+	CreateStackWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
+
+	CreateStack(ctx context.Context, body CreateStackJSONRequestBody) (*http.Response, error)
+
+	// DeleteStack request
+	DeleteStack(ctx context.Context, stackId string, params *DeleteStackParams) (*http.Response, error)
+
+	// ReadStack request
+	ReadStack(ctx context.Context, stackId string) (*http.Response, error)
+
+	// UpdateStack request  with any body
+	UpdateStackWithBody(ctx context.Context, stackId string, contentType string, body io.Reader) (*http.Response, error)
+
+	UpdateStack(ctx context.Context, stackId string, body UpdateStackJSONRequestBody) (*http.Response, error)
+
+	// UninstallStack request
+	UninstallStack(ctx context.Context, stackId string) (*http.Response, error)
 
 	// GetTasks request
 	GetTasks(ctx context.Context, params *GetTasksParams) (*http.Response, error)
@@ -753,6 +715,16 @@ type ClientInterface interface {
 
 	// DeleteTelegrafsIDOwnersID request
 	DeleteTelegrafsIDOwnersID(ctx context.Context, telegrafID string, userID string, params *DeleteTelegrafsIDOwnersIDParams) (*http.Response, error)
+
+	// ApplyTemplate request  with any body
+	ApplyTemplateWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
+
+	ApplyTemplate(ctx context.Context, body ApplyTemplateJSONRequestBody) (*http.Response, error)
+
+	// ExportTemplate request  with any body
+	ExportTemplateWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
+
+	ExportTemplate(ctx context.Context, body ExportTemplateJSONRequestBody) (*http.Response, error)
 
 	// GetUsers request
 	GetUsers(ctx context.Context, params *GetUsersParams) (*http.Response, error)
@@ -2041,78 +2013,6 @@ func (c *Client) PatchOrgsID(ctx context.Context, orgID string, params *PatchOrg
 	return c.service.DoHTTPRequestWithResponse(req, nil)
 }
 
-func (c *Client) PostOrgsIDInvitesWithBody(ctx context.Context, orgID string, params *PostOrgsIDInvitesParams, contentType string, body io.Reader) (*http.Response, error) {
-	req, err := NewPostOrgsIDInvitesRequestWithBody(c.service.ServerAPIURL(), orgID, params, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) PostOrgsIDInvites(ctx context.Context, orgID string, params *PostOrgsIDInvitesParams, body PostOrgsIDInvitesJSONRequestBody) (*http.Response, error) {
-	req, err := NewPostOrgsIDInvitesRequest(c.service.ServerAPIURL(), orgID, params, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) DeleteOrgsIDInviteID(ctx context.Context, orgID string, inviteID string, params *DeleteOrgsIDInviteIDParams) (*http.Response, error) {
-	req, err := NewDeleteOrgsIDInviteIDRequest(c.service.ServerAPIURL(), orgID, inviteID, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) PostOrgsIDInviteID(ctx context.Context, orgID string, inviteID string, params *PostOrgsIDInviteIDParams) (*http.Response, error) {
-	req, err := NewPostOrgsIDInviteIDRequest(c.service.ServerAPIURL(), orgID, inviteID, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) GetOrgsIDLabels(ctx context.Context, orgID string, params *GetOrgsIDLabelsParams) (*http.Response, error) {
-	req, err := NewGetOrgsIDLabelsRequest(c.service.ServerAPIURL(), orgID, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) PostOrgsIDLabelsWithBody(ctx context.Context, orgID string, params *PostOrgsIDLabelsParams, contentType string, body io.Reader) (*http.Response, error) {
-	req, err := NewPostOrgsIDLabelsRequestWithBody(c.service.ServerAPIURL(), orgID, params, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) PostOrgsIDLabels(ctx context.Context, orgID string, params *PostOrgsIDLabelsParams, body PostOrgsIDLabelsJSONRequestBody) (*http.Response, error) {
-	req, err := NewPostOrgsIDLabelsRequest(c.service.ServerAPIURL(), orgID, params, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) DeleteOrgsIDLabelsID(ctx context.Context, orgID string, labelID string, params *DeleteOrgsIDLabelsIDParams) (*http.Response, error) {
-	req, err := NewDeleteOrgsIDLabelsIDRequest(c.service.ServerAPIURL(), orgID, labelID, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
 func (c *Client) GetOrgsIDMembers(ctx context.Context, orgID string, params *GetOrgsIDMembersParams) (*http.Response, error) {
 	req, err := NewGetOrgsIDMembersRequest(c.service.ServerAPIURL(), orgID, params)
 	if err != nil {
@@ -2223,132 +2123,6 @@ func (c *Client) PostOrgsIDSecretsWithBody(ctx context.Context, orgID string, pa
 
 func (c *Client) PostOrgsIDSecrets(ctx context.Context, orgID string, params *PostOrgsIDSecretsParams, body PostOrgsIDSecretsJSONRequestBody) (*http.Response, error) {
 	req, err := NewPostOrgsIDSecretsRequest(c.service.ServerAPIURL(), orgID, params, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) GetCloudUsers(ctx context.Context, orgID string, params *GetCloudUsersParams) (*http.Response, error) {
-	req, err := NewGetCloudUsersRequest(c.service.ServerAPIURL(), orgID, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) DeleteOrgsIDCloudUserID(ctx context.Context, orgID string, userID string, params *DeleteOrgsIDCloudUserIDParams) (*http.Response, error) {
-	req, err := NewDeleteOrgsIDCloudUserIDRequest(c.service.ServerAPIURL(), orgID, userID, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) CreatePkgWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
-	req, err := NewCreatePkgRequestWithBody(c.service.ServerAPIURL(), contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) CreatePkg(ctx context.Context, body CreatePkgJSONRequestBody) (*http.Response, error) {
-	req, err := NewCreatePkgRequest(c.service.ServerAPIURL(), body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) ApplyPkgWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
-	req, err := NewApplyPkgRequestWithBody(c.service.ServerAPIURL(), contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) ApplyPkg(ctx context.Context, body ApplyPkgJSONRequestBody) (*http.Response, error) {
-	req, err := NewApplyPkgRequest(c.service.ServerAPIURL(), body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) ListStacks(ctx context.Context, params *ListStacksParams) (*http.Response, error) {
-	req, err := NewListStacksRequest(c.service.ServerAPIURL(), params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) CreateStackWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
-	req, err := NewCreateStackRequestWithBody(c.service.ServerAPIURL(), contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) CreateStack(ctx context.Context, body CreateStackJSONRequestBody) (*http.Response, error) {
-	req, err := NewCreateStackRequest(c.service.ServerAPIURL(), body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) DeleteStack(ctx context.Context, stackId string, params *DeleteStackParams) (*http.Response, error) {
-	req, err := NewDeleteStackRequest(c.service.ServerAPIURL(), stackId, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) ReadStack(ctx context.Context, stackId string) (*http.Response, error) {
-	req, err := NewReadStackRequest(c.service.ServerAPIURL(), stackId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) UpdateStackWithBody(ctx context.Context, stackId string, contentType string, body io.Reader) (*http.Response, error) {
-	req, err := NewUpdateStackRequestWithBody(c.service.ServerAPIURL(), stackId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) UpdateStack(ctx context.Context, stackId string, body UpdateStackJSONRequestBody) (*http.Response, error) {
-	req, err := NewUpdateStackRequest(c.service.ServerAPIURL(), stackId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	return c.service.DoHTTPRequestWithResponse(req, nil)
-}
-
-func (c *Client) ExportStack(ctx context.Context, stackId string, params *ExportStackParams) (*http.Response, error) {
-	req, err := NewExportStackRequest(c.service.ServerAPIURL(), stackId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2763,6 +2537,78 @@ func (c *Client) GetSourcesIDBuckets(ctx context.Context, sourceID string, param
 
 func (c *Client) GetSourcesIDHealth(ctx context.Context, sourceID string, params *GetSourcesIDHealthParams) (*http.Response, error) {
 	req, err := NewGetSourcesIDHealthRequest(c.service.ServerAPIURL(), sourceID, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return c.service.DoHTTPRequestWithResponse(req, nil)
+}
+
+func (c *Client) ListStacks(ctx context.Context, params *ListStacksParams) (*http.Response, error) {
+	req, err := NewListStacksRequest(c.service.ServerAPIURL(), params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return c.service.DoHTTPRequestWithResponse(req, nil)
+}
+
+func (c *Client) CreateStackWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewCreateStackRequestWithBody(c.service.ServerAPIURL(), contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return c.service.DoHTTPRequestWithResponse(req, nil)
+}
+
+func (c *Client) CreateStack(ctx context.Context, body CreateStackJSONRequestBody) (*http.Response, error) {
+	req, err := NewCreateStackRequest(c.service.ServerAPIURL(), body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return c.service.DoHTTPRequestWithResponse(req, nil)
+}
+
+func (c *Client) DeleteStack(ctx context.Context, stackId string, params *DeleteStackParams) (*http.Response, error) {
+	req, err := NewDeleteStackRequest(c.service.ServerAPIURL(), stackId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return c.service.DoHTTPRequestWithResponse(req, nil)
+}
+
+func (c *Client) ReadStack(ctx context.Context, stackId string) (*http.Response, error) {
+	req, err := NewReadStackRequest(c.service.ServerAPIURL(), stackId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return c.service.DoHTTPRequestWithResponse(req, nil)
+}
+
+func (c *Client) UpdateStackWithBody(ctx context.Context, stackId string, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewUpdateStackRequestWithBody(c.service.ServerAPIURL(), stackId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return c.service.DoHTTPRequestWithResponse(req, nil)
+}
+
+func (c *Client) UpdateStack(ctx context.Context, stackId string, body UpdateStackJSONRequestBody) (*http.Response, error) {
+	req, err := NewUpdateStackRequest(c.service.ServerAPIURL(), stackId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return c.service.DoHTTPRequestWithResponse(req, nil)
+}
+
+func (c *Client) UninstallStack(ctx context.Context, stackId string) (*http.Response, error) {
+	req, err := NewUninstallStackRequest(c.service.ServerAPIURL(), stackId)
 	if err != nil {
 		return nil, err
 	}
@@ -3186,6 +3032,42 @@ func (c *Client) PostTelegrafsIDOwners(ctx context.Context, telegrafID string, p
 
 func (c *Client) DeleteTelegrafsIDOwnersID(ctx context.Context, telegrafID string, userID string, params *DeleteTelegrafsIDOwnersIDParams) (*http.Response, error) {
 	req, err := NewDeleteTelegrafsIDOwnersIDRequest(c.service.ServerAPIURL(), telegrafID, userID, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return c.service.DoHTTPRequestWithResponse(req, nil)
+}
+
+func (c *Client) ApplyTemplateWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewApplyTemplateRequestWithBody(c.service.ServerAPIURL(), contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return c.service.DoHTTPRequestWithResponse(req, nil)
+}
+
+func (c *Client) ApplyTemplate(ctx context.Context, body ApplyTemplateJSONRequestBody) (*http.Response, error) {
+	req, err := NewApplyTemplateRequest(c.service.ServerAPIURL(), body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return c.service.DoHTTPRequestWithResponse(req, nil)
+}
+
+func (c *Client) ExportTemplateWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewExportTemplateRequestWithBody(c.service.ServerAPIURL(), contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return c.service.DoHTTPRequestWithResponse(req, nil)
+}
+
+func (c *Client) ExportTemplate(ctx context.Context, body ExportTemplateJSONRequestBody) (*http.Response, error) {
+	req, err := NewExportTemplateRequest(c.service.ServerAPIURL(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -8857,321 +8739,6 @@ func NewPatchOrgsIDRequestWithBody(server string, orgID string, params *PatchOrg
 	return req, nil
 }
 
-// NewPostOrgsIDInvitesRequest calls the generic PostOrgsIDInvites builder with application/json body
-func NewPostOrgsIDInvitesRequest(server string, orgID string, params *PostOrgsIDInvitesParams, body PostOrgsIDInvitesJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewPostOrgsIDInvitesRequestWithBody(server, orgID, params, "application/json", bodyReader)
-}
-
-// NewPostOrgsIDInvitesRequestWithBody generates requests for PostOrgsIDInvites with any type of body
-func NewPostOrgsIDInvitesRequestWithBody(server string, orgID string, params *PostOrgsIDInvitesParams, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "orgID", orgID)
-	if err != nil {
-		return nil, err
-	}
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/orgs/%s/invites", pathParam0)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	if params.ZapTraceSpan != nil {
-		var headerParam0 string
-
-		headerParam0, err = runtime.StyleParam("simple", false, "Zap-Trace-Span", *params.ZapTraceSpan)
-		if err != nil {
-			return nil, err
-		}
-
-		req.Header.Add("Zap-Trace-Span", headerParam0)
-	}
-
-	req.Header.Add("Content-Type", contentType)
-	return req, nil
-}
-
-// NewDeleteOrgsIDInviteIDRequest generates requests for DeleteOrgsIDInviteID
-func NewDeleteOrgsIDInviteIDRequest(server string, orgID string, inviteID string, params *DeleteOrgsIDInviteIDParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "orgID", orgID)
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParam("simple", false, "inviteID", inviteID)
-	if err != nil {
-		return nil, err
-	}
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/orgs/%s/invites/%s", pathParam0, pathParam1)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if params.ZapTraceSpan != nil {
-		var headerParam0 string
-
-		headerParam0, err = runtime.StyleParam("simple", false, "Zap-Trace-Span", *params.ZapTraceSpan)
-		if err != nil {
-			return nil, err
-		}
-
-		req.Header.Add("Zap-Trace-Span", headerParam0)
-	}
-
-	return req, nil
-}
-
-// NewPostOrgsIDInviteIDRequest generates requests for PostOrgsIDInviteID
-func NewPostOrgsIDInviteIDRequest(server string, orgID string, inviteID string, params *PostOrgsIDInviteIDParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "orgID", orgID)
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParam("simple", false, "inviteID", inviteID)
-	if err != nil {
-		return nil, err
-	}
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/orgs/%s/invites/%s/resend", pathParam0, pathParam1)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if params.ZapTraceSpan != nil {
-		var headerParam0 string
-
-		headerParam0, err = runtime.StyleParam("simple", false, "Zap-Trace-Span", *params.ZapTraceSpan)
-		if err != nil {
-			return nil, err
-		}
-
-		req.Header.Add("Zap-Trace-Span", headerParam0)
-	}
-
-	return req, nil
-}
-
-// NewGetOrgsIDLabelsRequest generates requests for GetOrgsIDLabels
-func NewGetOrgsIDLabelsRequest(server string, orgID string, params *GetOrgsIDLabelsParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "orgID", orgID)
-	if err != nil {
-		return nil, err
-	}
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/orgs/%s/labels", pathParam0)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if params.ZapTraceSpan != nil {
-		var headerParam0 string
-
-		headerParam0, err = runtime.StyleParam("simple", false, "Zap-Trace-Span", *params.ZapTraceSpan)
-		if err != nil {
-			return nil, err
-		}
-
-		req.Header.Add("Zap-Trace-Span", headerParam0)
-	}
-
-	return req, nil
-}
-
-// NewPostOrgsIDLabelsRequest calls the generic PostOrgsIDLabels builder with application/json body
-func NewPostOrgsIDLabelsRequest(server string, orgID string, params *PostOrgsIDLabelsParams, body PostOrgsIDLabelsJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewPostOrgsIDLabelsRequestWithBody(server, orgID, params, "application/json", bodyReader)
-}
-
-// NewPostOrgsIDLabelsRequestWithBody generates requests for PostOrgsIDLabels with any type of body
-func NewPostOrgsIDLabelsRequestWithBody(server string, orgID string, params *PostOrgsIDLabelsParams, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "orgID", orgID)
-	if err != nil {
-		return nil, err
-	}
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/orgs/%s/labels", pathParam0)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	if params.ZapTraceSpan != nil {
-		var headerParam0 string
-
-		headerParam0, err = runtime.StyleParam("simple", false, "Zap-Trace-Span", *params.ZapTraceSpan)
-		if err != nil {
-			return nil, err
-		}
-
-		req.Header.Add("Zap-Trace-Span", headerParam0)
-	}
-
-	req.Header.Add("Content-Type", contentType)
-	return req, nil
-}
-
-// NewDeleteOrgsIDLabelsIDRequest generates requests for DeleteOrgsIDLabelsID
-func NewDeleteOrgsIDLabelsIDRequest(server string, orgID string, labelID string, params *DeleteOrgsIDLabelsIDParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "orgID", orgID)
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParam("simple", false, "labelID", labelID)
-	if err != nil {
-		return nil, err
-	}
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/orgs/%s/labels/%s", pathParam0, pathParam1)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if params.ZapTraceSpan != nil {
-		var headerParam0 string
-
-		headerParam0, err = runtime.StyleParam("simple", false, "Zap-Trace-Span", *params.ZapTraceSpan)
-		if err != nil {
-			return nil, err
-		}
-
-		req.Header.Add("Zap-Trace-Span", headerParam0)
-	}
-
-	return req, nil
-}
-
 // NewGetOrgsIDMembersRequest generates requests for GetOrgsIDMembers
 func NewGetOrgsIDMembersRequest(server string, orgID string, params *GetOrgsIDMembersParams) (*http.Request, error) {
 	var err error
@@ -9636,475 +9203,6 @@ func NewPostOrgsIDSecretsRequestWithBody(server string, orgID string, params *Po
 	}
 
 	req.Header.Add("Content-Type", contentType)
-	return req, nil
-}
-
-// NewGetCloudUsersRequest generates requests for GetCloudUsers
-func NewGetCloudUsersRequest(server string, orgID string, params *GetCloudUsersParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "orgID", orgID)
-	if err != nil {
-		return nil, err
-	}
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/orgs/%s/users", pathParam0)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if params.ZapTraceSpan != nil {
-		var headerParam0 string
-
-		headerParam0, err = runtime.StyleParam("simple", false, "Zap-Trace-Span", *params.ZapTraceSpan)
-		if err != nil {
-			return nil, err
-		}
-
-		req.Header.Add("Zap-Trace-Span", headerParam0)
-	}
-
-	return req, nil
-}
-
-// NewDeleteOrgsIDCloudUserIDRequest generates requests for DeleteOrgsIDCloudUserID
-func NewDeleteOrgsIDCloudUserIDRequest(server string, orgID string, userID string, params *DeleteOrgsIDCloudUserIDParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "orgID", orgID)
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParam("simple", false, "userID", userID)
-	if err != nil {
-		return nil, err
-	}
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/orgs/%s/users/%s", pathParam0, pathParam1)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if params.ZapTraceSpan != nil {
-		var headerParam0 string
-
-		headerParam0, err = runtime.StyleParam("simple", false, "Zap-Trace-Span", *params.ZapTraceSpan)
-		if err != nil {
-			return nil, err
-		}
-
-		req.Header.Add("Zap-Trace-Span", headerParam0)
-	}
-
-	return req, nil
-}
-
-// NewCreatePkgRequest calls the generic CreatePkg builder with application/json body
-func NewCreatePkgRequest(server string, body CreatePkgJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewCreatePkgRequestWithBody(server, "application/json", bodyReader)
-}
-
-// NewCreatePkgRequestWithBody generates requests for CreatePkg with any type of body
-func NewCreatePkgRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/packages")
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-	return req, nil
-}
-
-// NewApplyPkgRequest calls the generic ApplyPkg builder with application/json body
-func NewApplyPkgRequest(server string, body ApplyPkgJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewApplyPkgRequestWithBody(server, "application/json", bodyReader)
-}
-
-// NewApplyPkgRequestWithBody generates requests for ApplyPkg with any type of body
-func NewApplyPkgRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/packages/apply")
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-	return req, nil
-}
-
-// NewListStacksRequest generates requests for ListStacks
-func NewListStacksRequest(server string, params *ListStacksParams) (*http.Request, error) {
-	var err error
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/packages/stacks")
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	queryValues := queryURL.Query()
-
-	if queryFrag, err := runtime.StyleParam("form", true, "orgID", params.OrgID); err != nil {
-		return nil, err
-	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-		return nil, err
-	} else {
-		for k, v := range parsed {
-			for _, v2 := range v {
-				queryValues.Add(k, v2)
-			}
-		}
-	}
-
-	if params.Name != nil {
-
-		if queryFrag, err := runtime.StyleParam("form", true, "name", *params.Name); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-	}
-
-	if params.StackID != nil {
-
-		if queryFrag, err := runtime.StyleParam("form", true, "stackID", *params.StackID); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-	}
-
-	queryURL.RawQuery = queryValues.Encode()
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewCreateStackRequest calls the generic CreateStack builder with application/json body
-func NewCreateStackRequest(server string, body CreateStackJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewCreateStackRequestWithBody(server, "application/json", bodyReader)
-}
-
-// NewCreateStackRequestWithBody generates requests for CreateStack with any type of body
-func NewCreateStackRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/packages/stacks")
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-	return req, nil
-}
-
-// NewDeleteStackRequest generates requests for DeleteStack
-func NewDeleteStackRequest(server string, stackId string, params *DeleteStackParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "stack_id", stackId)
-	if err != nil {
-		return nil, err
-	}
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/packages/stacks/%s", pathParam0)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	queryValues := queryURL.Query()
-
-	if queryFrag, err := runtime.StyleParam("form", true, "orgID", params.OrgID); err != nil {
-		return nil, err
-	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-		return nil, err
-	} else {
-		for k, v := range parsed {
-			for _, v2 := range v {
-				queryValues.Add(k, v2)
-			}
-		}
-	}
-
-	queryURL.RawQuery = queryValues.Encode()
-
-	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewReadStackRequest generates requests for ReadStack
-func NewReadStackRequest(server string, stackId string) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "stack_id", stackId)
-	if err != nil {
-		return nil, err
-	}
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/packages/stacks/%s", pathParam0)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewUpdateStackRequest calls the generic UpdateStack builder with application/json body
-func NewUpdateStackRequest(server string, stackId string, body UpdateStackJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewUpdateStackRequestWithBody(server, stackId, "application/json", bodyReader)
-}
-
-// NewUpdateStackRequestWithBody generates requests for UpdateStack with any type of body
-func NewUpdateStackRequestWithBody(server string, stackId string, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "stack_id", stackId)
-	if err != nil {
-		return nil, err
-	}
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/packages/stacks/%s", pathParam0)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("PATCH", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-	return req, nil
-}
-
-// NewExportStackRequest generates requests for ExportStack
-func NewExportStackRequest(server string, stackId string, params *ExportStackParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParam("simple", false, "stack_id", stackId)
-	if err != nil {
-		return nil, err
-	}
-
-	queryURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	basePath := fmt.Sprintf("/packages/stacks/%s/export", pathParam0)
-	if basePath[0] == '/' {
-		basePath = basePath[1:]
-	}
-
-	queryURL, err = queryURL.Parse(basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	queryValues := queryURL.Query()
-
-	if queryFrag, err := runtime.StyleParam("form", true, "orgID", params.OrgID); err != nil {
-		return nil, err
-	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-		return nil, err
-	} else {
-		for k, v := range parsed {
-			for _, v2 := range v {
-				queryValues.Add(k, v2)
-			}
-		}
-	}
-
-	queryURL.RawQuery = queryValues.Encode()
-
-	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
 	return req, nil
 }
 
@@ -11862,6 +10960,284 @@ func NewGetSourcesIDHealthRequest(server string, sourceID string, params *GetSou
 		}
 
 		req.Header.Add("Zap-Trace-Span", headerParam0)
+	}
+
+	return req, nil
+}
+
+// NewListStacksRequest generates requests for ListStacks
+func NewListStacksRequest(server string, params *ListStacksParams) (*http.Request, error) {
+	var err error
+
+	queryURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/stacks")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryURL, err = queryURL.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if queryFrag, err := runtime.StyleParam("form", true, "orgID", params.OrgID); err != nil {
+		return nil, err
+	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+		return nil, err
+	} else {
+		for k, v := range parsed {
+			for _, v2 := range v {
+				queryValues.Add(k, v2)
+			}
+		}
+	}
+
+	if params.Name != nil {
+
+		if queryFrag, err := runtime.StyleParam("form", true, "name", *params.Name); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.StackID != nil {
+
+		if queryFrag, err := runtime.StyleParam("form", true, "stackID", *params.StackID); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateStackRequest calls the generic CreateStack builder with application/json body
+func NewCreateStackRequest(server string, body CreateStackJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateStackRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateStackRequestWithBody generates requests for CreateStack with any type of body
+func NewCreateStackRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	queryURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/stacks")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryURL, err = queryURL.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewDeleteStackRequest generates requests for DeleteStack
+func NewDeleteStackRequest(server string, stackId string, params *DeleteStackParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "stack_id", stackId)
+	if err != nil {
+		return nil, err
+	}
+
+	queryURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/stacks/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryURL, err = queryURL.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if queryFrag, err := runtime.StyleParam("form", true, "orgID", params.OrgID); err != nil {
+		return nil, err
+	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+		return nil, err
+	} else {
+		for k, v := range parsed {
+			for _, v2 := range v {
+				queryValues.Add(k, v2)
+			}
+		}
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewReadStackRequest generates requests for ReadStack
+func NewReadStackRequest(server string, stackId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "stack_id", stackId)
+	if err != nil {
+		return nil, err
+	}
+
+	queryURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/stacks/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryURL, err = queryURL.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateStackRequest calls the generic UpdateStack builder with application/json body
+func NewUpdateStackRequest(server string, stackId string, body UpdateStackJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateStackRequestWithBody(server, stackId, "application/json", bodyReader)
+}
+
+// NewUpdateStackRequestWithBody generates requests for UpdateStack with any type of body
+func NewUpdateStackRequestWithBody(server string, stackId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "stack_id", stackId)
+	if err != nil {
+		return nil, err
+	}
+
+	queryURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/stacks/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryURL, err = queryURL.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewUninstallStackRequest generates requests for UninstallStack
+func NewUninstallStackRequest(server string, stackId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "stack_id", stackId)
+	if err != nil {
+		return nil, err
+	}
+
+	queryURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/stacks/%s/uninstall", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryURL, err = queryURL.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
 	}
 
 	return req, nil
@@ -13886,6 +13262,84 @@ func NewDeleteTelegrafsIDOwnersIDRequest(server string, telegrafID string, userI
 		req.Header.Add("Zap-Trace-Span", headerParam0)
 	}
 
+	return req, nil
+}
+
+// NewApplyTemplateRequest calls the generic ApplyTemplate builder with application/json body
+func NewApplyTemplateRequest(server string, body ApplyTemplateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewApplyTemplateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewApplyTemplateRequestWithBody generates requests for ApplyTemplate with any type of body
+func NewApplyTemplateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	queryURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/templates/apply")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryURL, err = queryURL.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewExportTemplateRequest calls the generic ExportTemplate builder with application/json body
+func NewExportTemplateRequest(server string, body ExportTemplateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewExportTemplateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewExportTemplateRequestWithBody generates requests for ExportTemplate with any type of body
+func NewExportTemplateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	queryURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/templates/export")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryURL, err = queryURL.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 	return req, nil
 }
 
@@ -17069,143 +16523,6 @@ func (r patchOrgsIDResponse) StatusCode() int {
 	return 0
 }
 
-type postOrgsIDInvitesResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON201      *Invite
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r postOrgsIDInvitesResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r postOrgsIDInvitesResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type deleteOrgsIDInviteIDResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r deleteOrgsIDInviteIDResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r deleteOrgsIDInviteIDResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type postOrgsIDInviteIDResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *Invite
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r postOrgsIDInviteIDResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r postOrgsIDInviteIDResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type getOrgsIDLabelsResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *LabelsResponse
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r getOrgsIDLabelsResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r getOrgsIDLabelsResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type postOrgsIDLabelsResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON201      *LabelResponse
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r postOrgsIDLabelsResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r postOrgsIDLabelsResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type deleteOrgsIDLabelsIDResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON404      *Error
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r deleteOrgsIDLabelsIDResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r deleteOrgsIDLabelsIDResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
 type getOrgsIDMembersResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -17405,239 +16722,6 @@ func (r postOrgsIDSecretsResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r postOrgsIDSecretsResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type getCloudUsersResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *CloudUsers
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r getCloudUsersResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r getCloudUsersResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type deleteOrgsIDCloudUserIDResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r deleteOrgsIDCloudUserIDResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r deleteOrgsIDCloudUserIDResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type createPkgResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *Pkg
-	YAML200      *Pkg
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r createPkgResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r createPkgResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type applyPkgResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *PkgSummary
-	JSON201      *PkgSummary
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r applyPkgResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r applyPkgResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type listStacksResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		Stacks *[]Stack `json:"stacks,omitempty"`
-	}
-	JSONDefault *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r listStacksResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r listStacksResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type createStackResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON201      *Stack
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r createStackResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r createStackResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type deleteStackResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r deleteStackResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r deleteStackResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type readStackResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *Stack
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r readStackResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r readStackResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type updateStackResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *Stack
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r updateStackResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r updateStackResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type exportStackResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *Pkg
-	YAML200      *Pkg
-	JSONDefault  *Error
-}
-
-// Status returns HTTPResponse.Status
-func (r exportStackResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r exportStackResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -18396,6 +17480,145 @@ func (r getSourcesIDHealthResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r getSourcesIDHealthResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type listStacksResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Stacks *[]Stack `json:"stacks,omitempty"`
+	}
+	JSONDefault *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r listStacksResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r listStacksResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type createStackResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *Stack
+	JSONDefault  *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r createStackResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r createStackResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type deleteStackResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSONDefault  *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r deleteStackResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r deleteStackResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type readStackResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Stack
+	JSONDefault  *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r readStackResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r readStackResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type updateStackResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Stack
+	JSONDefault  *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r updateStackResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r updateStackResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type uninstallStackResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Stack
+	JSONDefault  *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r uninstallStackResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r uninstallStackResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -19217,6 +18440,54 @@ func (r deleteTelegrafsIDOwnersIDResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r deleteTelegrafsIDOwnersIDResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type applyTemplateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *TemplateSummary
+	JSON201      *TemplateSummary
+	JSONDefault  *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r applyTemplateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r applyTemplateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type exportTemplateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Template
+	YAML200      *Template
+	JSONDefault  *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r exportTemplateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r exportTemplateResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -20778,76 +20049,6 @@ func (c *ClientWithResponses) PatchOrgsIDWithResponse(ctx context.Context, orgID
 	return ParsePatchOrgsIDResponse(rsp)
 }
 
-// PostOrgsIDInvitesWithBodyWithResponse request with arbitrary body returning *PostOrgsIDInvitesResponse
-func (c *ClientWithResponses) PostOrgsIDInvitesWithBodyWithResponse(ctx context.Context, orgID string, params *PostOrgsIDInvitesParams, contentType string, body io.Reader) (*postOrgsIDInvitesResponse, error) {
-	rsp, err := c.PostOrgsIDInvitesWithBody(ctx, orgID, params, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParsePostOrgsIDInvitesResponse(rsp)
-}
-
-func (c *ClientWithResponses) PostOrgsIDInvitesWithResponse(ctx context.Context, orgID string, params *PostOrgsIDInvitesParams, body PostOrgsIDInvitesJSONRequestBody) (*postOrgsIDInvitesResponse, error) {
-	rsp, err := c.PostOrgsIDInvites(ctx, orgID, params, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParsePostOrgsIDInvitesResponse(rsp)
-}
-
-// DeleteOrgsIDInviteIDWithResponse request returning *DeleteOrgsIDInviteIDResponse
-func (c *ClientWithResponses) DeleteOrgsIDInviteIDWithResponse(ctx context.Context, orgID string, inviteID string, params *DeleteOrgsIDInviteIDParams) (*deleteOrgsIDInviteIDResponse, error) {
-	rsp, err := c.DeleteOrgsIDInviteID(ctx, orgID, inviteID, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDeleteOrgsIDInviteIDResponse(rsp)
-}
-
-// PostOrgsIDInviteIDWithResponse request returning *PostOrgsIDInviteIDResponse
-func (c *ClientWithResponses) PostOrgsIDInviteIDWithResponse(ctx context.Context, orgID string, inviteID string, params *PostOrgsIDInviteIDParams) (*postOrgsIDInviteIDResponse, error) {
-	rsp, err := c.PostOrgsIDInviteID(ctx, orgID, inviteID, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParsePostOrgsIDInviteIDResponse(rsp)
-}
-
-// GetOrgsIDLabelsWithResponse request returning *GetOrgsIDLabelsResponse
-func (c *ClientWithResponses) GetOrgsIDLabelsWithResponse(ctx context.Context, orgID string, params *GetOrgsIDLabelsParams) (*getOrgsIDLabelsResponse, error) {
-	rsp, err := c.GetOrgsIDLabels(ctx, orgID, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetOrgsIDLabelsResponse(rsp)
-}
-
-// PostOrgsIDLabelsWithBodyWithResponse request with arbitrary body returning *PostOrgsIDLabelsResponse
-func (c *ClientWithResponses) PostOrgsIDLabelsWithBodyWithResponse(ctx context.Context, orgID string, params *PostOrgsIDLabelsParams, contentType string, body io.Reader) (*postOrgsIDLabelsResponse, error) {
-	rsp, err := c.PostOrgsIDLabelsWithBody(ctx, orgID, params, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParsePostOrgsIDLabelsResponse(rsp)
-}
-
-func (c *ClientWithResponses) PostOrgsIDLabelsWithResponse(ctx context.Context, orgID string, params *PostOrgsIDLabelsParams, body PostOrgsIDLabelsJSONRequestBody) (*postOrgsIDLabelsResponse, error) {
-	rsp, err := c.PostOrgsIDLabels(ctx, orgID, params, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParsePostOrgsIDLabelsResponse(rsp)
-}
-
-// DeleteOrgsIDLabelsIDWithResponse request returning *DeleteOrgsIDLabelsIDResponse
-func (c *ClientWithResponses) DeleteOrgsIDLabelsIDWithResponse(ctx context.Context, orgID string, labelID string, params *DeleteOrgsIDLabelsIDParams) (*deleteOrgsIDLabelsIDResponse, error) {
-	rsp, err := c.DeleteOrgsIDLabelsID(ctx, orgID, labelID, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDeleteOrgsIDLabelsIDResponse(rsp)
-}
-
 // GetOrgsIDMembersWithResponse request returning *GetOrgsIDMembersResponse
 func (c *ClientWithResponses) GetOrgsIDMembersWithResponse(ctx context.Context, orgID string, params *GetOrgsIDMembersParams) (*getOrgsIDMembersResponse, error) {
 	rsp, err := c.GetOrgsIDMembers(ctx, orgID, params)
@@ -20959,128 +20160,6 @@ func (c *ClientWithResponses) PostOrgsIDSecretsWithResponse(ctx context.Context,
 		return nil, err
 	}
 	return ParsePostOrgsIDSecretsResponse(rsp)
-}
-
-// GetCloudUsersWithResponse request returning *GetCloudUsersResponse
-func (c *ClientWithResponses) GetCloudUsersWithResponse(ctx context.Context, orgID string, params *GetCloudUsersParams) (*getCloudUsersResponse, error) {
-	rsp, err := c.GetCloudUsers(ctx, orgID, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetCloudUsersResponse(rsp)
-}
-
-// DeleteOrgsIDCloudUserIDWithResponse request returning *DeleteOrgsIDCloudUserIDResponse
-func (c *ClientWithResponses) DeleteOrgsIDCloudUserIDWithResponse(ctx context.Context, orgID string, userID string, params *DeleteOrgsIDCloudUserIDParams) (*deleteOrgsIDCloudUserIDResponse, error) {
-	rsp, err := c.DeleteOrgsIDCloudUserID(ctx, orgID, userID, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDeleteOrgsIDCloudUserIDResponse(rsp)
-}
-
-// CreatePkgWithBodyWithResponse request with arbitrary body returning *CreatePkgResponse
-func (c *ClientWithResponses) CreatePkgWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*createPkgResponse, error) {
-	rsp, err := c.CreatePkgWithBody(ctx, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreatePkgResponse(rsp)
-}
-
-func (c *ClientWithResponses) CreatePkgWithResponse(ctx context.Context, body CreatePkgJSONRequestBody) (*createPkgResponse, error) {
-	rsp, err := c.CreatePkg(ctx, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreatePkgResponse(rsp)
-}
-
-// ApplyPkgWithBodyWithResponse request with arbitrary body returning *ApplyPkgResponse
-func (c *ClientWithResponses) ApplyPkgWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*applyPkgResponse, error) {
-	rsp, err := c.ApplyPkgWithBody(ctx, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParseApplyPkgResponse(rsp)
-}
-
-func (c *ClientWithResponses) ApplyPkgWithResponse(ctx context.Context, body ApplyPkgJSONRequestBody) (*applyPkgResponse, error) {
-	rsp, err := c.ApplyPkg(ctx, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParseApplyPkgResponse(rsp)
-}
-
-// ListStacksWithResponse request returning *ListStacksResponse
-func (c *ClientWithResponses) ListStacksWithResponse(ctx context.Context, params *ListStacksParams) (*listStacksResponse, error) {
-	rsp, err := c.ListStacks(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParseListStacksResponse(rsp)
-}
-
-// CreateStackWithBodyWithResponse request with arbitrary body returning *CreateStackResponse
-func (c *ClientWithResponses) CreateStackWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*createStackResponse, error) {
-	rsp, err := c.CreateStackWithBody(ctx, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreateStackResponse(rsp)
-}
-
-func (c *ClientWithResponses) CreateStackWithResponse(ctx context.Context, body CreateStackJSONRequestBody) (*createStackResponse, error) {
-	rsp, err := c.CreateStack(ctx, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreateStackResponse(rsp)
-}
-
-// DeleteStackWithResponse request returning *DeleteStackResponse
-func (c *ClientWithResponses) DeleteStackWithResponse(ctx context.Context, stackId string, params *DeleteStackParams) (*deleteStackResponse, error) {
-	rsp, err := c.DeleteStack(ctx, stackId, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDeleteStackResponse(rsp)
-}
-
-// ReadStackWithResponse request returning *ReadStackResponse
-func (c *ClientWithResponses) ReadStackWithResponse(ctx context.Context, stackId string) (*readStackResponse, error) {
-	rsp, err := c.ReadStack(ctx, stackId)
-	if err != nil {
-		return nil, err
-	}
-	return ParseReadStackResponse(rsp)
-}
-
-// UpdateStackWithBodyWithResponse request with arbitrary body returning *UpdateStackResponse
-func (c *ClientWithResponses) UpdateStackWithBodyWithResponse(ctx context.Context, stackId string, contentType string, body io.Reader) (*updateStackResponse, error) {
-	rsp, err := c.UpdateStackWithBody(ctx, stackId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUpdateStackResponse(rsp)
-}
-
-func (c *ClientWithResponses) UpdateStackWithResponse(ctx context.Context, stackId string, body UpdateStackJSONRequestBody) (*updateStackResponse, error) {
-	rsp, err := c.UpdateStack(ctx, stackId, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUpdateStackResponse(rsp)
-}
-
-// ExportStackWithResponse request returning *ExportStackResponse
-func (c *ClientWithResponses) ExportStackWithResponse(ctx context.Context, stackId string, params *ExportStackParams) (*exportStackResponse, error) {
-	rsp, err := c.ExportStack(ctx, stackId, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParseExportStackResponse(rsp)
 }
 
 // PostQueryWithBodyWithResponse request with arbitrary body returning *PostQueryResponse
@@ -21482,6 +20561,76 @@ func (c *ClientWithResponses) GetSourcesIDHealthWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseGetSourcesIDHealthResponse(rsp)
+}
+
+// ListStacksWithResponse request returning *ListStacksResponse
+func (c *ClientWithResponses) ListStacksWithResponse(ctx context.Context, params *ListStacksParams) (*listStacksResponse, error) {
+	rsp, err := c.ListStacks(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListStacksResponse(rsp)
+}
+
+// CreateStackWithBodyWithResponse request with arbitrary body returning *CreateStackResponse
+func (c *ClientWithResponses) CreateStackWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*createStackResponse, error) {
+	rsp, err := c.CreateStackWithBody(ctx, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateStackResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateStackWithResponse(ctx context.Context, body CreateStackJSONRequestBody) (*createStackResponse, error) {
+	rsp, err := c.CreateStack(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateStackResponse(rsp)
+}
+
+// DeleteStackWithResponse request returning *DeleteStackResponse
+func (c *ClientWithResponses) DeleteStackWithResponse(ctx context.Context, stackId string, params *DeleteStackParams) (*deleteStackResponse, error) {
+	rsp, err := c.DeleteStack(ctx, stackId, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteStackResponse(rsp)
+}
+
+// ReadStackWithResponse request returning *ReadStackResponse
+func (c *ClientWithResponses) ReadStackWithResponse(ctx context.Context, stackId string) (*readStackResponse, error) {
+	rsp, err := c.ReadStack(ctx, stackId)
+	if err != nil {
+		return nil, err
+	}
+	return ParseReadStackResponse(rsp)
+}
+
+// UpdateStackWithBodyWithResponse request with arbitrary body returning *UpdateStackResponse
+func (c *ClientWithResponses) UpdateStackWithBodyWithResponse(ctx context.Context, stackId string, contentType string, body io.Reader) (*updateStackResponse, error) {
+	rsp, err := c.UpdateStackWithBody(ctx, stackId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateStackResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateStackWithResponse(ctx context.Context, stackId string, body UpdateStackJSONRequestBody) (*updateStackResponse, error) {
+	rsp, err := c.UpdateStack(ctx, stackId, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateStackResponse(rsp)
+}
+
+// UninstallStackWithResponse request returning *UninstallStackResponse
+func (c *ClientWithResponses) UninstallStackWithResponse(ctx context.Context, stackId string) (*uninstallStackResponse, error) {
+	rsp, err := c.UninstallStack(ctx, stackId)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUninstallStackResponse(rsp)
 }
 
 // GetTasksWithResponse request returning *GetTasksResponse
@@ -21894,6 +21043,40 @@ func (c *ClientWithResponses) DeleteTelegrafsIDOwnersIDWithResponse(ctx context.
 		return nil, err
 	}
 	return ParseDeleteTelegrafsIDOwnersIDResponse(rsp)
+}
+
+// ApplyTemplateWithBodyWithResponse request with arbitrary body returning *ApplyTemplateResponse
+func (c *ClientWithResponses) ApplyTemplateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*applyTemplateResponse, error) {
+	rsp, err := c.ApplyTemplateWithBody(ctx, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseApplyTemplateResponse(rsp)
+}
+
+func (c *ClientWithResponses) ApplyTemplateWithResponse(ctx context.Context, body ApplyTemplateJSONRequestBody) (*applyTemplateResponse, error) {
+	rsp, err := c.ApplyTemplate(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseApplyTemplateResponse(rsp)
+}
+
+// ExportTemplateWithBodyWithResponse request with arbitrary body returning *ExportTemplateResponse
+func (c *ClientWithResponses) ExportTemplateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*exportTemplateResponse, error) {
+	rsp, err := c.ExportTemplateWithBody(ctx, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseExportTemplateResponse(rsp)
+}
+
+func (c *ClientWithResponses) ExportTemplateWithResponse(ctx context.Context, body ExportTemplateJSONRequestBody) (*exportTemplateResponse, error) {
+	rsp, err := c.ExportTemplate(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseExportTemplateResponse(rsp)
 }
 
 // GetUsersWithResponse request returning *GetUsersResponse
@@ -25437,197 +24620,6 @@ func ParsePatchOrgsIDResponse(rsp *http.Response) (*patchOrgsIDResponse, error) 
 	return response, nil
 }
 
-// ParsePostOrgsIDInvitesResponse parses an HTTP response from a PostOrgsIDInvitesWithResponse call
-func ParsePostOrgsIDInvitesResponse(rsp *http.Response) (*postOrgsIDInvitesResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &postOrgsIDInvitesResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest Invite
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON201 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseDeleteOrgsIDInviteIDResponse parses an HTTP response from a DeleteOrgsIDInviteIDWithResponse call
-func ParseDeleteOrgsIDInviteIDResponse(rsp *http.Response) (*deleteOrgsIDInviteIDResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &deleteOrgsIDInviteIDResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParsePostOrgsIDInviteIDResponse parses an HTTP response from a PostOrgsIDInviteIDWithResponse call
-func ParsePostOrgsIDInviteIDResponse(rsp *http.Response) (*postOrgsIDInviteIDResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &postOrgsIDInviteIDResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Invite
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseGetOrgsIDLabelsResponse parses an HTTP response from a GetOrgsIDLabelsWithResponse call
-func ParseGetOrgsIDLabelsResponse(rsp *http.Response) (*getOrgsIDLabelsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &getOrgsIDLabelsResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest LabelsResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParsePostOrgsIDLabelsResponse parses an HTTP response from a PostOrgsIDLabelsWithResponse call
-func ParsePostOrgsIDLabelsResponse(rsp *http.Response) (*postOrgsIDLabelsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &postOrgsIDLabelsResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest LabelResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON201 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseDeleteOrgsIDLabelsIDResponse parses an HTTP response from a DeleteOrgsIDLabelsIDWithResponse call
-func ParseDeleteOrgsIDLabelsIDResponse(rsp *http.Response) (*deleteOrgsIDLabelsIDResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &deleteOrgsIDLabelsIDResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseGetOrgsIDMembersResponse parses an HTTP response from a GetOrgsIDMembersWithResponse call
 func ParseGetOrgsIDMembersResponse(rsp *http.Response) (*getOrgsIDMembersResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -25905,345 +24897,6 @@ func ParsePostOrgsIDSecretsResponse(rsp *http.Response) (*postOrgsIDSecretsRespo
 			return nil, err
 		}
 		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseGetCloudUsersResponse parses an HTTP response from a GetCloudUsersWithResponse call
-func ParseGetCloudUsersResponse(rsp *http.Response) (*getCloudUsersResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &getCloudUsersResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest CloudUsers
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseDeleteOrgsIDCloudUserIDResponse parses an HTTP response from a DeleteOrgsIDCloudUserIDWithResponse call
-func ParseDeleteOrgsIDCloudUserIDResponse(rsp *http.Response) (*deleteOrgsIDCloudUserIDResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &deleteOrgsIDCloudUserIDResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseCreatePkgResponse parses an HTTP response from a CreatePkgWithResponse call
-func ParseCreatePkgResponse(rsp *http.Response) (*createPkgResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &createPkgResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Pkg
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.YAML200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "yaml") && rsp.StatusCode == 200:
-		var dest Pkg
-		if err := yaml.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.YAML200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseApplyPkgResponse parses an HTTP response from a ApplyPkgWithResponse call
-func ParseApplyPkgResponse(rsp *http.Response) (*applyPkgResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &applyPkgResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest PkgSummary
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest PkgSummary
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON201 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseListStacksResponse parses an HTTP response from a ListStacksWithResponse call
-func ParseListStacksResponse(rsp *http.Response) (*listStacksResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &listStacksResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			Stacks *[]Stack `json:"stacks,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseCreateStackResponse parses an HTTP response from a CreateStackWithResponse call
-func ParseCreateStackResponse(rsp *http.Response) (*createStackResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &createStackResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest Stack
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON201 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseDeleteStackResponse parses an HTTP response from a DeleteStackWithResponse call
-func ParseDeleteStackResponse(rsp *http.Response) (*deleteStackResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &deleteStackResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseReadStackResponse parses an HTTP response from a ReadStackWithResponse call
-func ParseReadStackResponse(rsp *http.Response) (*readStackResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &readStackResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Stack
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseUpdateStackResponse parses an HTTP response from a UpdateStackWithResponse call
-func ParseUpdateStackResponse(rsp *http.Response) (*updateStackResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &updateStackResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Stack
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseExportStackResponse parses an HTTP response from a ExportStackWithResponse call
-func ParseExportStackResponse(rsp *http.Response) (*exportStackResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &exportStackResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Pkg
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.YAML200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSONDefault = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "yaml") && rsp.StatusCode == 200:
-		var dest Pkg
-		if err := yaml.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.YAML200 = &dest
 
 	}
 
@@ -27319,6 +25972,199 @@ func ParseGetSourcesIDHealthResponse(rsp *http.Response) (*getSourcesIDHealthRes
 			return nil, err
 		}
 		response.JSON503 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListStacksResponse parses an HTTP response from a ListStacksWithResponse call
+func ParseListStacksResponse(rsp *http.Response) (*listStacksResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &listStacksResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Stacks *[]Stack `json:"stacks,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateStackResponse parses an HTTP response from a CreateStackWithResponse call
+func ParseCreateStackResponse(rsp *http.Response) (*createStackResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &createStackResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest Stack
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteStackResponse parses an HTTP response from a DeleteStackWithResponse call
+func ParseDeleteStackResponse(rsp *http.Response) (*deleteStackResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &deleteStackResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseReadStackResponse parses an HTTP response from a ReadStackWithResponse call
+func ParseReadStackResponse(rsp *http.Response) (*readStackResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &readStackResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Stack
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateStackResponse parses an HTTP response from a UpdateStackWithResponse call
+func ParseUpdateStackResponse(rsp *http.Response) (*updateStackResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &updateStackResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Stack
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUninstallStackResponse parses an HTTP response from a UninstallStackWithResponse call
+func ParseUninstallStackResponse(rsp *http.Response) (*uninstallStackResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &uninstallStackResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Stack
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
 		var dest Error
@@ -28468,6 +27314,86 @@ func ParseDeleteTelegrafsIDOwnersIDResponse(rsp *http.Response) (*deleteTelegraf
 			return nil, err
 		}
 		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseApplyTemplateResponse parses an HTTP response from a ApplyTemplateWithResponse call
+func ParseApplyTemplateResponse(rsp *http.Response) (*applyTemplateResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &applyTemplateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest TemplateSummary
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest TemplateSummary
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseExportTemplateResponse parses an HTTP response from a ExportTemplateWithResponse call
+func ParseExportTemplateResponse(rsp *http.Response) (*exportTemplateResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &exportTemplateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Template
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.YAML200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "yaml") && rsp.StatusCode == 200:
+		var dest Template
+		if err := yaml.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.YAML200 = &dest
 
 	}
 

--- a/domain/swagger.yml
+++ b/domain/swagger.yml
@@ -2449,7 +2449,7 @@ paths:
               - "UpdatedAt"
         - in: query
           name: id
-          description: List of dashboard IDs to return. If both `id and `owner` are specified, only `id` is used.
+          description: List of dashboard IDs to return. If both `id` and `owner` are specified, only `id` is used.
           schema:
             type: array
             items:
@@ -4083,101 +4083,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  "/orgs/{orgID}/labels":
-    get:
-      operationId: GetOrgsIDLabels
-      tags:
-        - Organizations
-      summary: List all labels for a organization
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - in: path
-          name: orgID
-          schema:
-            type: string
-          required: true
-          description: The organization ID.
-      responses:
-        "200":
-          description: A list of all labels for an organization
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LabelsResponse"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-    post:
-      operationId: PostOrgsIDLabels
-      tags:
-        - Organizations
-      summary: Add a label to an organization
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - in: path
-          name: orgID
-          schema:
-            type: string
-          required: true
-          description: The organization ID.
-      requestBody:
-        description: Label to add
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LabelMapping"
-      responses:
-        "201":
-          description: Returns the created label
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LabelResponse"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-  "/orgs/{orgID}/labels/{labelID}":
-    delete:
-      operationId: DeleteOrgsIDLabelsID
-      tags:
-        - Organizations
-      summary: Delete a label from an organization
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - in: path
-          name: orgID
-          schema:
-            type: string
-          required: true
-          description: The organization ID.
-        - in: path
-          name: labelID
-          schema:
-            type: string
-          required: true
-          description: The label ID.
-      responses:
-        "204":
-          description: Delete has been accepted
-        "404":
-          description: Organization not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
   "/orgs/{orgID}/secrets":
     get:
       operationId: GetOrgsIDSecrets
@@ -4433,161 +4338,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  "/orgs/{orgID}/invites":
-    post:
-      operationId: PostOrgsIDInvites
-      tags:
-        - Invites
-        - Organizations
-      summary: Creates an invite to an organization
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - in: path
-          name: orgID
-          schema:
-            type: string
-          required: true
-          description: The organization ID.
-      requestBody:
-        description: Invite to be sent
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Invite"
-      responses:
-        "201":
-          description: Invite sent
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Invite"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-  "/orgs/{orgID}/invites/{inviteID}":
-    delete:
-      operationId: DeleteOrgsIDInviteID
-      tags:
-        - Invites
-        - Organizations
-      summary: Remove an invite to an organization
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - in: path
-          name: inviteID
-          schema:
-            type: string
-          required: true
-          description: The ID of the invite to remove.
-        - in: path
-          name: orgID
-          schema:
-            type: string
-          required: true
-          description: The organization ID.
-      responses:
-        "204":
-          description: Invite removed
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-  "/orgs/{orgID}/invites/{inviteID}/resend":
-    post:
-      operationId: PostOrgsIDInviteID
-      tags:
-        - Invites
-        - Organizations
-      summary: Resends an invite
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - in: path
-          name: inviteID
-          schema:
-            type: string
-          required: true
-          description: The ID of the invite to resend.
-        - in: path
-          name: orgID
-          schema:
-            type: string
-          required: true
-          description: The organization ID.
-      responses:
-        "200":
-          description: Invite resent
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Invite"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-  "/orgs/{orgID}/users":
-    get:
-      operationId: GetCloudUsers
-      tags:
-        - CloudUsers
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - in: path
-          name: orgID
-          description: Specifies the organization ID of the CloudUser.
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: A list of cloud users
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CloudUsers"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-  "/orgs/{orgID}/users/{userID}":
-    delete:
-      operationId: DeleteOrgsIDCloudUserID
-      tags:
-        - CloudUsers
-        - Organizations
-      summary: Deletes a cloud user
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - in: path
-          name: userID
-          schema:
-            type: string
-          required: true
-          description: The ID of the user to remove.
-        - in: path
-          name: orgID
-          schema:
-            type: string
-          required: true
-          description: The organization ID.
-      responses:
-        "204":
-          description: User removed
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
   "/orgs/{orgID}/owners/{userID}":
     delete:
       operationId: DeleteOrgsIDOwnersID
@@ -4618,85 +4368,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /packages:
-    post:
-      operationId: CreatePkg
-      tags:
-        - InfluxPackages
-      summary: Create a new Influx package
-      requestBody:
-        description: Influx package to create.
-        required: false
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PkgCreate"
-      responses:
-        "200":
-          description: Influx package created
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Pkg"
-            application/x-yaml:
-              schema:
-                $ref: "#/components/schemas/Pkg"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-  /packages/apply:
-    post:
-      operationId: ApplyPkg
-      tags:
-        - InfluxPackages
-      summary: Apply or dry-run an Influx package
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PkgApply"
-          application/x-jsonnet:
-            schema:
-              $ref: "#/components/schemas/PkgApply"
-          text/yml:
-            schema:
-              $ref: "#/components/schemas/PkgApply"
-      responses:
-        "200":
-          description: >
-            Influx package dry-run successful, no new resources created.
-            The provided diff and summary will not have IDs for resources
-            that do not exist at the time of the dry run.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PkgSummary"
-        "201":
-          description: >
-            Influx package applied successfully. Newly created resources created
-            available in summary. The diff compares the state of the world before
-            the package is applied with the changes the application will impose.
-            This corresponds to `"dryRun": true`
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PkgSummary"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-  /packages/stacks:
+  /stacks:
     get:
       operationId: ListStacks
       tags:
-        - InfluxPackages
-      summary: Grab a list of installed Influx packages
+        - InfluxDB Templates
+      summary: Grab a list of installed InfluxDB Templates
       parameters:
         - in: query
           name: orgID
@@ -4735,10 +4412,10 @@ paths:
     post:
       operationId: CreateStack
       tags:
-        - InfluxPackages
+        - InfluxDB Templates
       summary: Create a new stack
       requestBody:
-        description: Influx stack to create.
+        description: Stack to create.
         required: true
         content:
           application/json:
@@ -4757,7 +4434,7 @@ paths:
                     type: string
       responses:
         "201":
-          description: Influx stack created
+          description: InfluxDB Stack created
           content:
             application/json:
               schema:
@@ -4768,11 +4445,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /packages/stacks/{stack_id}:
+  /stacks/{stack_id}:
     get:
       operationId: ReadStack
       tags:
-        - InfluxPackages
+        - InfluxDB Templates
       summary: Grab a stack by its ID
       parameters:
         - in: path
@@ -4797,8 +4474,8 @@ paths:
     patch:
       operationId: UpdateStack
       tags:
-        - InfluxPackages
-      summary: Update a an Influx Stack
+        - InfluxDB Templates
+      summary: Update an InfluxDB Stack
       parameters:
         - in: path
           name: stack_id
@@ -4816,12 +4493,27 @@ paths:
               properties:
                 name:
                   type: string
+                  nullable: true
                 description:
                   type: string
-                urls:
+                  nullable: true
+                templateURLs:
                   type: array
                   items:
                     type: string
+                  nullable: true
+                additionalResources:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      resourceID:
+                        type: string
+                      kind:
+                        type: string
+                      templateMetaName:
+                        type: string
+                    required: ["kind","resourceID"]
       responses:
         "200":
           description: Influx stack updated
@@ -4838,7 +4530,7 @@ paths:
     delete:
       operationId: DeleteStack
       tags:
-        - InfluxPackages
+        - InfluxDB Templates
       summary: Delete a stack and remove all its associated resources
       parameters:
         - in: path
@@ -4862,35 +4554,99 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /packages/stacks/{stack_id}/export:
-    delete:
-      operationId: ExportStack
+  /stacks/{stack_id}/uninstall:
+    post:
+      operationId: UninstallStack
       tags:
-        - InfluxPackages
-      summary: Export a stack's resources in the form of a package
+        - InfluxDB Templates
+      summary: Uninstall an InfluxDB Stack
       parameters:
         - in: path
           name: stack_id
           required: true
           schema:
             type: string
-          description: The stack id to be removed
-        - in: query
-          name: orgID
-          required: true
-          schema:
-            type: string
-          description: The organization id of the user
+          description: The stack id
       responses:
         "200":
-          description: Stack and all its associated resources are deleted
+          description: Influx stack uninstalled
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Pkg"
+                $ref: "#/components/schemas/Stack"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /templates/apply:
+    post:
+      operationId: ApplyTemplate
+      tags:
+        - InfluxDB Templates
+      summary: Apply or dry-run an InfluxDB Template
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TemplateApply"
+          application/x-jsonnet:
+            schema:
+              $ref: "#/components/schemas/TemplateApply"
+          text/yml:
+            schema:
+              $ref: "#/components/schemas/TemplateApply"
+      responses:
+        "200":
+          description: >
+            Influx package dry-run successful, no new resources created.
+            The provided diff and summary will not have IDs for resources
+            that do not exist at the time of the dry run.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TemplateSummary"
+        "201":
+          description: >
+            Influx package applied successfully. Newly created resources created
+            available in summary. The diff compares the state of the world before
+            the package is applied with the changes the application will impose.
+            This corresponds to `"dryRun": true`
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TemplateSummary"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /templates/export:
+    post:
+      operationId: ExportTemplate
+      tags:
+        - InfluxDB Templates
+      summary: Export a new Influx Template
+      requestBody:
+        description: Export resources as an InfluxDB template.
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TemplateExport"
+      responses:
+        "200":
+          description: InfluxDB template created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Template"
             application/x-yaml:
               schema:
-                $ref: "#/components/schemas/Pkg"
+                $ref: "#/components/schemas/Template"
         default:
           description: Unexpected error
           content:
@@ -7453,7 +7209,7 @@ components:
           type: string
         retentionRules:
           $ref: "#/components/schemas/RetentionRules"
-      required: [name, retentionRules]
+      required: [orgID, name, retentionRules]
     Bucket:
       properties:
         links:
@@ -7644,7 +7400,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Organization"
-    PkgApply:
+    TemplateApply:
       type: object
       properties:
         dryRun:
@@ -7662,8 +7418,8 @@ components:
               type: array
               items:
                 type: string
-            package:
-              $ref: "#/components/schemas/Pkg"
+            contents:
+              $ref: "#/components/schemas/Template"
         templates:
           type: array
           items:
@@ -7675,8 +7431,16 @@ components:
                 type: array
                 items:
                   type: string
-              package:
-                $ref: "#/components/schemas/Pkg"
+              contents:
+                $ref: "#/components/schemas/Template"
+        envRefs:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: integer
+              - type: number
+              - type: boolean
         secrets:
           type: object
           additionalProperties:
@@ -7736,9 +7500,11 @@ components:
         - Task
         - Telegraf
         - Variable
-    PkgCreate:
+    TemplateExport:
       type: object
       properties:
+        stackID:
+          type: string
         orgIDs:
           type: array
           items:
@@ -7767,7 +7533,7 @@ components:
             name:
               type: string
           required: [id, kind]
-    Pkg:
+    Template:
       type: array
       items:
         type: object
@@ -7783,7 +7549,7 @@ components:
                 type: string
           spec:
             type: object
-    PkgEnvReferences:
+    TemplateEnvReferences:
       type: array
       items:
         type: object
@@ -7795,13 +7561,23 @@ components:
             type: string
             description: Key identified as environment reference and is the key identified in the template
           value:
-            type: string
             description: Value provided to fulfill reference
+            nullable: true
+            oneOf:
+              - type: string
+              - type: integer
+              - type: number
+              - type: boolean
           defaultValue:
-            type: string
             description: Default value that will be provided for the reference when no value is provided
-        required: [resourceField, envRefKey, defaultValue]
-    PkgSummary:
+            nullable: true
+            oneOf:
+              - type: string
+              - type: integer
+              - type: number
+              - type: boolean
+        required: [resourceField, envRefKey]
+    TemplateSummary:
       type: object
       properties:
         sources:
@@ -7822,7 +7598,9 @@ components:
                     type: string
                   orgID:
                     type: string
-                  pkgName:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
+                  templateMetaName:
                     type: string
                   name:
                     type: string
@@ -7833,9 +7611,9 @@ components:
                   labelAssociations:
                     type: array
                     items:
-                      $ref: "#/components/schemas/PkgSummaryLabel"
+                      $ref: "#/components/schemas/TemplateSummaryLabel"
                   envReferences:
-                    $ref: "#/components/schemas/PkgEnvReferences"
+                    $ref: "#/components/schemas/TemplateEnvReferences"
             checks:
               type: array
               items:
@@ -7843,18 +7621,16 @@ components:
                   - $ref: "#/components/schemas/CheckDiscriminator"
                   - type: object
                     properties:
-                      pkgName:
+                      kind:
+                        $ref: "#/components/schemas/TemplateKind"
+                      templateMetaName:
                         type: string
                       labelAssociations:
                         type: array
                         items:
-                          $ref: "#/components/schemas/PkgSummaryLabel"
+                          $ref: "#/components/schemas/TemplateSummaryLabel"
                       envReferences:
-                        $ref: "#/components/schemas/PkgEnvReferences"
-            labels:
-              type: array
-              items:
-                $ref: "#/components/schemas/PkgSummaryLabel"
+                        $ref: "#/components/schemas/TemplateEnvReferences"
             dashboards:
               type: array
               items:
@@ -7864,7 +7640,9 @@ components:
                     type: "string"
                   orgID:
                     type: "string"
-                  pkgName:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
+                  templateMetaName:
                     type: string
                   name:
                     type: "string"
@@ -7873,13 +7651,17 @@ components:
                   labelAssociations:
                     type: array
                     items:
-                      $ref: "#/components/schemas/PkgSummaryLabel"
+                      $ref: "#/components/schemas/TemplateSummaryLabel"
                   charts:
                     type: array
                     items:
-                      $ref: "#/components/schemas/PkgChart"
+                      $ref: "#/components/schemas/TemplateChart"
                   envReferences:
-                    $ref: "#/components/schemas/PkgEnvReferences"
+                    $ref: "#/components/schemas/TemplateEnvReferences"
+            labels:
+              type: array
+              items:
+                $ref: "#/components/schemas/TemplateSummaryLabel"
             labelMappings:
               type: array
               items:
@@ -7887,7 +7669,7 @@ components:
                 properties:
                   status:
                     type: string
-                  resourcePkgName:
+                  resourceTemplateMetaName:
                     type: string
                   resourceName:
                     type: string
@@ -7895,7 +7677,7 @@ components:
                     type: string
                   resourceType:
                     type: string
-                  labelPkgName:
+                  labelTemplateMetaName:
                     type: string
                   labelName:
                     type: string
@@ -7916,26 +7698,30 @@ components:
                   - $ref: "#/components/schemas/NotificationEndpointDiscrimator"
                   - type: object
                     properties:
-                      pkgName:
+                      kind:
+                        $ref: "#/components/schemas/TemplateKind"
+                      templateMetaName:
                         type: string
                       labelAssociations:
                         type: array
                         items:
-                          $ref: "#/components/schemas/PkgSummaryLabel"
+                          $ref: "#/components/schemas/TemplateSummaryLabel"
                       envReferences:
-                        $ref: "#/components/schemas/PkgEnvReferences"
+                        $ref: "#/components/schemas/TemplateEnvReferences"
             notificationRules:
               type: array
               items:
                 type: object
                 properties:
-                  pkgName:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
+                  templateMetaName:
                     type: string
                   name:
                     type: string
                   description:
                     type: string
-                  endpointPkgName:
+                  endpointTemplateMetaName:
                     type: string
                   endpointID:
                     type: string
@@ -7972,15 +7758,17 @@ components:
                   labelAssociations:
                     type: array
                     items:
-                      $ref: "#/components/schemas/PkgSummaryLabel"
+                      $ref: "#/components/schemas/TemplateSummaryLabel"
                   envReferences:
-                    $ref: "#/components/schemas/PkgEnvReferences"
+                    $ref: "#/components/schemas/TemplateEnvReferences"
             tasks:
               type: array
               items:
                 type: object
                 properties:
-                  pkgName:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
+                  templateMetaName:
                     type: string
                   id:
                     type: string
@@ -7999,7 +7787,7 @@ components:
                   status:
                     type: string
                   envReferences:
-                    $ref: "#/components/schemas/PkgEnvReferences"
+                    $ref: "#/components/schemas/TemplateEnvReferences"
             telegrafConfigs:
               type: array
               items:
@@ -8007,20 +7795,24 @@ components:
                   - $ref: "#/components/schemas/TelegrafRequest"
                   - type: object
                     properties:
-                      pkgName:
+                      kind:
+                        $ref: "#/components/schemas/TemplateKind"
+                      templateMetaName:
                         type: string
                       labelAssociations:
                         type: array
                         items:
-                          $ref: "#/components/schemas/PkgSummaryLabel"
+                          $ref: "#/components/schemas/TemplateSummaryLabel"
                       envReferences:
-                        $ref: "#/components/schemas/PkgEnvReferences"
+                        $ref: "#/components/schemas/TemplateEnvReferences"
             variables:
               type: array
               items:
                 type: object
                 properties:
-                  pkgName:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
+                  templateMetaName:
                     type: string
                   id:
                     type: string
@@ -8035,9 +7827,9 @@ components:
                   labelAssociations:
                     type: array
                     items:
-                      $ref: "#/components/schemas/PkgSummaryLabel"
+                      $ref: "#/components/schemas/TemplateSummaryLabel"
                   envReferences:
-                    $ref: "#/components/schemas/PkgEnvReferences"
+                    $ref: "#/components/schemas/TemplateEnvReferences"
         diff:
           type: object
           properties:
@@ -8046,11 +7838,13 @@ components:
               items:
                 type: object
                 properties:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   stateStatus:
                     type: string
                   id:
                     type: string
-                  pkgName:
+                  templateMetaName:
                     type: string
                   new:
                     type: object
@@ -8075,11 +7869,13 @@ components:
               items:
                 type: object
                 properties:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   stateStatus:
                     type: string
                   id:
                     type: string
-                  pkgName:
+                  templateMetaName:
                     type: string
                   new:
                     $ref: "#/components/schemas/CheckDiscriminator"
@@ -8094,7 +7890,9 @@ components:
                     type: string
                   id:
                     type: string
-                  pkgName:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
+                  templateMetaName:
                     type: string
                   new:
                     type: object
@@ -8106,7 +7904,7 @@ components:
                       charts:
                         type: array
                         items:
-                          $ref: "#/components/schemas/PkgChart"
+                          $ref: "#/components/schemas/TemplateChart"
                   old:
                     type: object
                     properties:
@@ -8117,7 +7915,7 @@ components:
                       charts:
                         type: array
                         items:
-                          $ref: "#/components/schemas/PkgChart"
+                          $ref: "#/components/schemas/TemplateChart"
             labels:
               type: array
               items:
@@ -8125,9 +7923,11 @@ components:
                 properties:
                   stateStatus:
                     type: string
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   id:
                     type: string
-                  pkgName:
+                  templateMetaName:
                     type: string
                   new:
                     type: object
@@ -8158,13 +7958,13 @@ components:
                     type: string
                   resourceID:
                     type: string
-                  resourcePkgName:
+                  resourceTemplateMetaName:
                     type: string
                   resourceName:
                     type: string
                   labelID:
                     type: string
-                  labelPkgName:
+                  labelTemplateMetaName:
                     type: string
                   labelName:
                     type: string
@@ -8173,11 +7973,13 @@ components:
               items:
                 type: object
                 properties:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   stateStatus:
                     type: string
                   id:
                     type: string
-                  pkgName:
+                  templateMetaName:
                     type: string
                   new:
                     $ref: "#/components/schemas/NotificationEndpointDiscrimator"
@@ -8188,11 +7990,13 @@ components:
               items:
                 type: object
                 properties:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   stateStatus:
                     type: string
                   id:
                     type: string
-                  pkgName:
+                  templateMetaName:
                     type: string
                   new:
                     type: object
@@ -8281,11 +8085,13 @@ components:
               items:
                 type: object
                 properties:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   stateStatus:
                     type: string
                   id:
                     type: string
-                  pkgName:
+                  templateMetaName:
                     type: string
                   new:
                     type: object
@@ -8326,11 +8132,13 @@ components:
               items:
                 type: object
                 properties:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   stateStatus:
                     type: string
                   id:
                     type: string
-                  pkgName:
+                  templateMetaName:
                     type: string
                   new:
                     $ref: "#/components/schemas/TelegrafRequest"
@@ -8341,11 +8149,13 @@ components:
               items:
                 type: object
                 properties:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   stateStatus:
                     type: string
                   id:
                     type: string
-                  pkgName:
+                  templateMetaName:
                     type: string
                   new:
                     type: object
@@ -8382,14 +8192,16 @@ components:
                 type: array
                 items:
                   type: integer
-    PkgSummaryLabel:
+    TemplateSummaryLabel:
       type: object
       properties:
         id:
           type: string
         orgID:
           type: string
-        pkgName:
+        kind:
+          $ref: "#/components/schemas/TemplateKind"
+        templateMetaName:
           type: string
         name:
           type: string
@@ -8401,8 +8213,8 @@ components:
             description:
               type: string
         envReferences:
-          $ref: "#/components/schemas/PkgEnvReferences"
-    PkgChart:
+          $ref: "#/components/schemas/TemplateEnvReferences"
+    TemplateChart:
       type: object
       properties:
         xPos:
@@ -8422,48 +8234,60 @@ components:
           type: string
         orgID:
           type: string
-        name:
-          type: string
-        description:
-          type: string
-        sources:
-          type: array
-          items:
-            type: string
-        resources:
-          type: array
-          items:
-            type: object
-            properties:
-              apiVersion:
-                type: string
-              resourceID:
-                type: string
-              kind:
-                $ref: "#/components/schemas/TemplateKind"
-              pkgName:
-                type: string
-              associations:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    kind:
-                      $ref: "#/components/schemas/TemplateKind"
-                    pkgName:
-                      type: string
-        urls:
-          type: array
-          items:
-            type: string
         createdAt:
           type: string
           format: date-time
           readOnly: true
-        updatedAt:
-          type: string
-          format: date-time
-          readOnly: true
+        events:
+          type: array
+          items:
+            type: object
+            properties:
+              eventType:
+                type: string
+              name:
+                type: string
+              description:
+                type: string
+              sources:
+                type: array
+                items:
+                  type: string
+              resources:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    apiVersion:
+                      type: string
+                    resourceID:
+                      type: string
+                    kind:
+                      $ref: "#/components/schemas/TemplateKind"
+                    templateMetaName:
+                      type: string
+                    associations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          kind:
+                            $ref: "#/components/schemas/TemplateKind"
+                          metaName:
+                            type: string
+                    links:
+                      type: object
+                      properties:
+                        self:
+                          type: string
+              urls:
+                type: array
+                items:
+                  type: string
+              updatedAt:
+                type: string
+                format: date-time
+                readOnly: true
     Runs:
       type: object
       properties:
@@ -8685,46 +8509,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Invite"
-    CloudUser:
-      properties:
-        id:
-          description: the idpe id of the user
-          readOnly: true
-          type: string
-        firstName:
-          type: string
-        lastName:
-          type: string
-        email:
-          type: string
-        role:
-          type: string
-          enum:
-            - member
-            - owner
-        links:
-          type: object
-          readOnly: true
-          example:
-            self: "/api/v2/cloud_users/1"
-          properties:
-            self:
-              type: string
-              format: uri
-      required: [id, email, role]
-    CloudUsers:
-      type: object
-      properties:
-        links:
-          type: object
-          properties:
-            self:
-              type: string
-              format: uri
-        users:
-          type: array
-          items:
-            $ref: "#/components/schemas/CloudUser"
     User:
       properties:
         id:
@@ -9031,6 +8815,8 @@ components:
           properties:
             period:
               type: string
+            fillValues:
+              type: boolean
     BuilderTagsType:
       type: object
       properties:
@@ -9187,6 +8973,9 @@ components:
           type: string
         shadeBelow:
           type: boolean
+        hoverDimension:
+          type: string
+          enum: [auto, x, y, xy]
         position:
           type: string
           enum: [overlaid, stacked]
@@ -9243,6 +9032,9 @@ components:
           type: string
         shadeBelow:
           type: boolean
+        hoverDimension:
+          type: string
+          enum: [auto, x, y, xy]
         position:
           type: string
           enum: [overlaid, stacked]
@@ -9252,6 +9044,81 @@ components:
           type: string
         decimalPlaces:
           $ref: "#/components/schemas/DecimalPlaces"
+    MosaicViewProperties:
+      type: object
+      required:
+        - type
+        - queries
+        - colors
+        - shape
+        - note
+        - showNoteWhenEmpty
+        - xColumn
+        - ySeriesColumns
+        - fillColumns
+        - xDomain
+        - yDomain
+        - xAxisLabel
+        - yAxisLabel
+        - xPrefix
+        - yPrefix
+        - xSuffix
+        - ySuffix
+      properties:
+        timeFormat:
+          type: string
+        type:
+          type: string
+          enum: [mosaic]
+        queries:
+          type: array
+          items:
+            $ref: "#/components/schemas/DashboardQuery"
+        colors:
+          description: Colors define color encoding of data into a visualization
+          type: array
+          items:
+            type: string
+        shape:
+          type: string
+          enum: ["chronograf-v2"]
+        note:
+          type: string
+        showNoteWhenEmpty:
+          description: If true, will display note when empty
+          type: boolean
+        xColumn:
+          type: string
+        ySeriesColumns:
+          type: array
+          items:
+            type: string
+        fillColumns:
+          type: array
+          items:
+            type: string
+        xDomain:
+          type: array
+          items:
+            type: number
+          maxItems: 2
+        yDomain:
+          type: array
+          items:
+            type: number
+          maxItems: 2
+        xAxisLabel:
+          type: string
+        yAxisLabel:
+          type: string
+        xPrefix:
+          type: string
+        xSuffix:
+          type: string
+        yPrefix:
+          type: string
+        ySuffix:
+          type: string
     ScatterViewProperties:
       type: object
       required:
@@ -9834,6 +9701,7 @@ components:
         - $ref: "#/components/schemas/CheckViewProperties"
         - $ref: "#/components/schemas/ScatterViewProperties"
         - $ref: "#/components/schemas/HeatmapViewProperties"
+        - $ref: "#/components/schemas/MosaicViewProperties"
     View:
       required:
         - name
@@ -10868,7 +10736,6 @@ components:
           type: integer
       required:
         - username
-        - password
         - org
         - bucket
     OnboardingResponse:

--- a/domain/types.gen.go
+++ b/domain/types.gen.go
@@ -86,13 +86,6 @@ const (
 	CheckViewPropertiesTypeCheck CheckViewPropertiesType = "check"
 )
 
-// Defines values for CloudUserRole.
-const (
-	CloudUserRoleMember CloudUserRole = "member"
-
-	CloudUserRoleOwner CloudUserRole = "owner"
-)
-
 // Defines values for ConstantVariablePropertiesType.
 const (
 	ConstantVariablePropertiesTypeConstant ConstantVariablePropertiesType = "constant"
@@ -284,6 +277,17 @@ const (
 	LesserThresholdTypeLesser LesserThresholdType = "lesser"
 )
 
+// Defines values for LinePlusSingleStatPropertiesHoverDimension.
+const (
+	LinePlusSingleStatPropertiesHoverDimensionAuto LinePlusSingleStatPropertiesHoverDimension = "auto"
+
+	LinePlusSingleStatPropertiesHoverDimensionTrue LinePlusSingleStatPropertiesHoverDimension = "true"
+
+	LinePlusSingleStatPropertiesHoverDimensionX LinePlusSingleStatPropertiesHoverDimension = "x"
+
+	LinePlusSingleStatPropertiesHoverDimensionXy LinePlusSingleStatPropertiesHoverDimension = "xy"
+)
+
 // Defines values for LinePlusSingleStatPropertiesPosition.
 const (
 	LinePlusSingleStatPropertiesPositionOverlaid LinePlusSingleStatPropertiesPosition = "overlaid"
@@ -334,6 +338,16 @@ const (
 // Defines values for MarkdownViewPropertiesType.
 const (
 	MarkdownViewPropertiesTypeMarkdown MarkdownViewPropertiesType = "markdown"
+)
+
+// Defines values for MosaicViewPropertiesShape.
+const (
+	MosaicViewPropertiesShapeChronografV2 MosaicViewPropertiesShape = "chronograf-v2"
+)
+
+// Defines values for MosaicViewPropertiesType.
+const (
+	MosaicViewPropertiesTypeMosaic MosaicViewPropertiesType = "mosaic"
 )
 
 // Defines values for NotificationEndpointBaseStatus.
@@ -894,6 +908,17 @@ const (
 	XYGeomStep XYGeom = "step"
 )
 
+// Defines values for XYViewPropertiesHoverDimension.
+const (
+	XYViewPropertiesHoverDimensionAuto XYViewPropertiesHoverDimension = "auto"
+
+	XYViewPropertiesHoverDimensionTrue XYViewPropertiesHoverDimension = "true"
+
+	XYViewPropertiesHoverDimensionX XYViewPropertiesHoverDimension = "x"
+
+	XYViewPropertiesHoverDimensionXy XYViewPropertiesHoverDimension = "xy"
+)
+
 // Defines values for XYViewPropertiesPosition.
 const (
 	XYViewPropertiesPositionOverlaid XYViewPropertiesPosition = "overlaid"
@@ -1126,7 +1151,8 @@ type BuilderAggregateFunctionType string
 // BuilderConfig defines model for BuilderConfig.
 type BuilderConfig struct {
 	AggregateWindow *struct {
-		Period *string `json:"period,omitempty"`
+		FillValues *bool   `json:"fillValues,omitempty"`
+		Period     *string `json:"period,omitempty"`
 	} `json:"aggregateWindow,omitempty"`
 	Buckets   *[]string               `json:"buckets,omitempty"`
 	Functions *[]BuilderFunctionsType `json:"functions,omitempty"`
@@ -1294,31 +1320,6 @@ type CheckViewPropertiesType string
 type Checks struct {
 	Checks *[]Check `json:"checks,omitempty"`
 	Links  *Links   `json:"links,omitempty"`
-}
-
-// CloudUser defines model for CloudUser.
-type CloudUser struct {
-	Email     string  `json:"email"`
-	FirstName *string `json:"firstName,omitempty"`
-
-	// the idpe id of the user
-	Id       string  `json:"id"`
-	LastName *string `json:"lastName,omitempty"`
-	Links    *struct {
-		Self *string `json:"self,omitempty"`
-	} `json:"links,omitempty"`
-	Role CloudUserRole `json:"role"`
-}
-
-// CloudUserRole defines model for CloudUser.Role.
-type CloudUserRole string
-
-// CloudUsers defines model for CloudUsers.
-type CloudUsers struct {
-	Links *struct {
-		Self *string `json:"self,omitempty"`
-	} `json:"links,omitempty"`
-	Users *[]CloudUser `json:"users,omitempty"`
 }
 
 // ConditionalExpression defines model for ConditionalExpression.
@@ -2161,7 +2162,8 @@ type LinePlusSingleStatProperties struct {
 	Colors []DashboardColor `json:"colors"`
 
 	// Indicates whether decimal places should be enforced, and how many digits it should show.
-	DecimalPlaces DecimalPlaces `json:"decimalPlaces"`
+	DecimalPlaces  DecimalPlaces                               `json:"decimalPlaces"`
+	HoverDimension *LinePlusSingleStatPropertiesHoverDimension `json:"hoverDimension,omitempty"`
 
 	// Legend define encoding of data into a view's legend
 	Legend     Legend                               `json:"legend"`
@@ -2180,6 +2182,9 @@ type LinePlusSingleStatProperties struct {
 	XColumn           *string                          `json:"xColumn,omitempty"`
 	YColumn           *string                          `json:"yColumn,omitempty"`
 }
+
+// LinePlusSingleStatPropertiesHoverDimension defines model for LinePlusSingleStatProperties.HoverDimension.
+type LinePlusSingleStatPropertiesHoverDimension string
 
 // LinePlusSingleStatPropertiesPosition defines model for LinePlusSingleStatProperties.Position.
 type LinePlusSingleStatPropertiesPosition string
@@ -2315,6 +2320,38 @@ type MemberExpression struct {
 	// Type of AST node
 	Type *NodeType `json:"type,omitempty"`
 }
+
+// MosaicViewProperties defines model for MosaicViewProperties.
+type MosaicViewProperties struct {
+
+	// Colors define color encoding of data into a visualization
+	Colors      []string                  `json:"colors"`
+	FillColumns []string                  `json:"fillColumns"`
+	Note        string                    `json:"note"`
+	Queries     []DashboardQuery          `json:"queries"`
+	Shape       MosaicViewPropertiesShape `json:"shape"`
+
+	// If true, will display note when empty
+	ShowNoteWhenEmpty bool                     `json:"showNoteWhenEmpty"`
+	TimeFormat        *string                  `json:"timeFormat,omitempty"`
+	Type              MosaicViewPropertiesType `json:"type"`
+	XAxisLabel        string                   `json:"xAxisLabel"`
+	XColumn           string                   `json:"xColumn"`
+	XDomain           []float32                `json:"xDomain"`
+	XPrefix           string                   `json:"xPrefix"`
+	XSuffix           string                   `json:"xSuffix"`
+	YAxisLabel        string                   `json:"yAxisLabel"`
+	YDomain           []float32                `json:"yDomain"`
+	YPrefix           string                   `json:"yPrefix"`
+	YSeriesColumns    []string                 `json:"ySeriesColumns"`
+	YSuffix           string                   `json:"ySuffix"`
+}
+
+// MosaicViewPropertiesShape defines model for MosaicViewProperties.Shape.
+type MosaicViewPropertiesShape string
+
+// MosaicViewPropertiesType defines model for MosaicViewProperties.Type.
+type MosaicViewPropertiesType string
 
 // Node defines model for Node.
 type Node interface{}
@@ -2489,11 +2526,11 @@ type ObjectExpression struct {
 
 // OnboardingRequest defines model for OnboardingRequest.
 type OnboardingRequest struct {
-	Bucket             string `json:"bucket"`
-	Org                string `json:"org"`
-	Password           string `json:"password"`
-	RetentionPeriodHrs *int   `json:"retentionPeriodHrs,omitempty"`
-	Username           string `json:"username"`
+	Bucket             string  `json:"bucket"`
+	Org                string  `json:"org"`
+	Password           *string `json:"password,omitempty"`
+	RetentionPeriodHrs *int    `json:"retentionPeriodHrs,omitempty"`
+	Username           string  `json:"username"`
 }
 
 // OnboardingResponse defines model for OnboardingResponse.
@@ -2651,384 +2688,11 @@ type PipeLiteral struct {
 	Type *NodeType `json:"type,omitempty"`
 }
 
-// Pkg defines model for Pkg.
-type Pkg []struct {
-	ApiVersion *string       `json:"apiVersion,omitempty"`
-	Kind       *TemplateKind `json:"kind,omitempty"`
-	Meta       *struct {
-		Name *string `json:"name,omitempty"`
-	} `json:"meta,omitempty"`
-	Spec *map[string]interface{} `json:"spec,omitempty"`
-}
-
-// PkgApply defines model for PkgApply.
-type PkgApply struct {
-	Actions *[]interface{} `json:"actions,omitempty"`
-	DryRun  *bool          `json:"dryRun,omitempty"`
-	OrgID   *string        `json:"orgID,omitempty"`
-	Remotes *[]struct {
-		ContentType *string `json:"contentType,omitempty"`
-		Url         string  `json:"url"`
-	} `json:"remotes,omitempty"`
-	Secrets  *PkgApply_Secrets `json:"secrets,omitempty"`
-	StackID  *string           `json:"stackID,omitempty"`
-	Template *struct {
-		ContentType *string   `json:"contentType,omitempty"`
-		Package     *Pkg      `json:"package,omitempty"`
-		Sources     *[]string `json:"sources,omitempty"`
-	} `json:"template,omitempty"`
-	Templates *[]struct {
-		ContentType *string   `json:"contentType,omitempty"`
-		Package     *Pkg      `json:"package,omitempty"`
-		Sources     *[]string `json:"sources,omitempty"`
-	} `json:"templates,omitempty"`
-}
-
-// PkgApply_Secrets defines model for PkgApply.Secrets.
-type PkgApply_Secrets struct {
-	AdditionalProperties map[string]string `json:"-"`
-}
-
-// PkgChart defines model for PkgChart.
-type PkgChart struct {
-	Height     *int            `json:"height,omitempty"`
-	Properties *ViewProperties `json:"properties,omitempty"`
-	Width      *int            `json:"width,omitempty"`
-	XPos       *int            `json:"xPos,omitempty"`
-	YPos       *int            `json:"yPos,omitempty"`
-}
-
-// PkgCreate defines model for PkgCreate.
-type PkgCreate struct {
-	OrgIDs *[]struct {
-		OrgID           *string `json:"orgID,omitempty"`
-		ResourceFilters *struct {
-			ByLabel        *[]string       `json:"byLabel,omitempty"`
-			ByResourceKind *[]TemplateKind `json:"byResourceKind,omitempty"`
-		} `json:"resourceFilters,omitempty"`
-	} `json:"orgIDs,omitempty"`
-	Resources *struct {
-		Id   string       `json:"id"`
-		Kind TemplateKind `json:"kind"`
-		Name *string      `json:"name,omitempty"`
-	} `json:"resources,omitempty"`
-}
-
-// PkgEnvReferences defines model for PkgEnvReferences.
-type PkgEnvReferences []struct {
-
-	// Default value that will be provided for the reference when no value is provided
-	DefaultValue string `json:"defaultValue"`
-
-	// Key identified as environment reference and is the key identified in the template
-	EnvRefKey string `json:"envRefKey"`
-
-	// Field the environment reference corresponds too
-	ResourceField string `json:"resourceField"`
-
-	// Value provided to fulfill reference
-	Value *string `json:"value,omitempty"`
-}
-
-// PkgSummary defines model for PkgSummary.
-type PkgSummary struct {
-	Diff *struct {
-		Buckets *[]struct {
-			Id  *string `json:"id,omitempty"`
-			New *struct {
-				Description *string `json:"description,omitempty"`
-				Name        *string `json:"name,omitempty"`
-
-				// Rules to expire or retain data.  No rules means data never expires.
-				RetentionRules *RetentionRules `json:"retentionRules,omitempty"`
-			} `json:"new,omitempty"`
-			Old *struct {
-				Description *string `json:"description,omitempty"`
-				Name        *string `json:"name,omitempty"`
-
-				// Rules to expire or retain data.  No rules means data never expires.
-				RetentionRules *RetentionRules `json:"retentionRules,omitempty"`
-			} `json:"old,omitempty"`
-			PkgName     *string `json:"pkgName,omitempty"`
-			StateStatus *string `json:"stateStatus,omitempty"`
-		} `json:"buckets,omitempty"`
-		Checks *[]struct {
-			Id          *string             `json:"id,omitempty"`
-			New         *CheckDiscriminator `json:"new,omitempty"`
-			Old         *CheckDiscriminator `json:"old,omitempty"`
-			PkgName     *string             `json:"pkgName,omitempty"`
-			StateStatus *string             `json:"stateStatus,omitempty"`
-		} `json:"checks,omitempty"`
-		Dashboards *[]struct {
-			Id  *string `json:"id,omitempty"`
-			New *struct {
-				Charts      *[]PkgChart `json:"charts,omitempty"`
-				Description *string     `json:"description,omitempty"`
-				Name        *string     `json:"name,omitempty"`
-			} `json:"new,omitempty"`
-			Old *struct {
-				Charts      *[]PkgChart `json:"charts,omitempty"`
-				Description *string     `json:"description,omitempty"`
-				Name        *string     `json:"name,omitempty"`
-			} `json:"old,omitempty"`
-			PkgName     *string `json:"pkgName,omitempty"`
-			StateStatus *string `json:"stateStatus,omitempty"`
-		} `json:"dashboards,omitempty"`
-		LabelMappings *[]struct {
-			LabelID         *string `json:"labelID,omitempty"`
-			LabelName       *string `json:"labelName,omitempty"`
-			LabelPkgName    *string `json:"labelPkgName,omitempty"`
-			ResourceID      *string `json:"resourceID,omitempty"`
-			ResourceName    *string `json:"resourceName,omitempty"`
-			ResourcePkgName *string `json:"resourcePkgName,omitempty"`
-			ResourceType    *string `json:"resourceType,omitempty"`
-			Status          *string `json:"status,omitempty"`
-		} `json:"labelMappings,omitempty"`
-		Labels *[]struct {
-			Id  *string `json:"id,omitempty"`
-			New *struct {
-				Color       *string `json:"color,omitempty"`
-				Description *string `json:"description,omitempty"`
-				Name        *string `json:"name,omitempty"`
-			} `json:"new,omitempty"`
-			Old *struct {
-				Color       *string `json:"color,omitempty"`
-				Description *string `json:"description,omitempty"`
-				Name        *string `json:"name,omitempty"`
-			} `json:"old,omitempty"`
-			PkgName     *string `json:"pkgName,omitempty"`
-			StateStatus *string `json:"stateStatus,omitempty"`
-		} `json:"labels,omitempty"`
-		NotificationEndpoints *[]struct {
-			Id          *string                          `json:"id,omitempty"`
-			New         *NotificationEndpointDiscrimator `json:"new,omitempty"`
-			Old         *NotificationEndpointDiscrimator `json:"old,omitempty"`
-			PkgName     *string                          `json:"pkgName,omitempty"`
-			StateStatus *string                          `json:"stateStatus,omitempty"`
-		} `json:"notificationEndpoints,omitempty"`
-		NotificationRules *[]struct {
-			Id  *string `json:"id,omitempty"`
-			New *struct {
-				Description     *string `json:"description,omitempty"`
-				EndpointID      *string `json:"endpointID,omitempty"`
-				EndpointName    *string `json:"endpointName,omitempty"`
-				EndpointType    *string `json:"endpointType,omitempty"`
-				Every           *string `json:"every,omitempty"`
-				MessageTemplate *string `json:"messageTemplate,omitempty"`
-				Name            *string `json:"name,omitempty"`
-				Offset          *string `json:"offset,omitempty"`
-				Status          *string `json:"status,omitempty"`
-				StatusRules     *[]struct {
-					CurrentLevel  *string `json:"currentLevel,omitempty"`
-					PreviousLevel *string `json:"previousLevel,omitempty"`
-				} `json:"statusRules,omitempty"`
-				TagRules *[]struct {
-					Key      *string `json:"key,omitempty"`
-					Operator *string `json:"operator,omitempty"`
-					Value    *string `json:"value,omitempty"`
-				} `json:"tagRules,omitempty"`
-			} `json:"new,omitempty"`
-			Old *struct {
-				Description     *string `json:"description,omitempty"`
-				EndpointID      *string `json:"endpointID,omitempty"`
-				EndpointName    *string `json:"endpointName,omitempty"`
-				EndpointType    *string `json:"endpointType,omitempty"`
-				Every           *string `json:"every,omitempty"`
-				MessageTemplate *string `json:"messageTemplate,omitempty"`
-				Name            *string `json:"name,omitempty"`
-				Offset          *string `json:"offset,omitempty"`
-				Status          *string `json:"status,omitempty"`
-				StatusRules     *[]struct {
-					CurrentLevel  *string `json:"currentLevel,omitempty"`
-					PreviousLevel *string `json:"previousLevel,omitempty"`
-				} `json:"statusRules,omitempty"`
-				TagRules *[]struct {
-					Key      *string `json:"key,omitempty"`
-					Operator *string `json:"operator,omitempty"`
-					Value    *string `json:"value,omitempty"`
-				} `json:"tagRules,omitempty"`
-			} `json:"old,omitempty"`
-			PkgName     *string `json:"pkgName,omitempty"`
-			StateStatus *string `json:"stateStatus,omitempty"`
-		} `json:"notificationRules,omitempty"`
-		Tasks *[]struct {
-			Id  *string `json:"id,omitempty"`
-			New *struct {
-				Cron        *string `json:"cron,omitempty"`
-				Description *string `json:"description,omitempty"`
-				Every       *string `json:"every,omitempty"`
-				Name        *string `json:"name,omitempty"`
-				Offset      *string `json:"offset,omitempty"`
-				Query       *string `json:"query,omitempty"`
-				Status      *string `json:"status,omitempty"`
-			} `json:"new,omitempty"`
-			Old *struct {
-				Cron        *string `json:"cron,omitempty"`
-				Description *string `json:"description,omitempty"`
-				Every       *string `json:"every,omitempty"`
-				Name        *string `json:"name,omitempty"`
-				Offset      *string `json:"offset,omitempty"`
-				Query       *string `json:"query,omitempty"`
-				Status      *string `json:"status,omitempty"`
-			} `json:"old,omitempty"`
-			PkgName     *string `json:"pkgName,omitempty"`
-			StateStatus *string `json:"stateStatus,omitempty"`
-		} `json:"tasks,omitempty"`
-		TelegrafConfigs *[]struct {
-			Id          *string          `json:"id,omitempty"`
-			New         *TelegrafRequest `json:"new,omitempty"`
-			Old         *TelegrafRequest `json:"old,omitempty"`
-			PkgName     *string          `json:"pkgName,omitempty"`
-			StateStatus *string          `json:"stateStatus,omitempty"`
-		} `json:"telegrafConfigs,omitempty"`
-		Variables *[]struct {
-			Id  *string `json:"id,omitempty"`
-			New *struct {
-				Args        *VariableProperties `json:"args,omitempty"`
-				Description *string             `json:"description,omitempty"`
-				Name        *string             `json:"name,omitempty"`
-			} `json:"new,omitempty"`
-			Old *struct {
-				Args        *VariableProperties `json:"args,omitempty"`
-				Description *string             `json:"description,omitempty"`
-				Name        *string             `json:"name,omitempty"`
-			} `json:"old,omitempty"`
-			PkgName     *string `json:"pkgName,omitempty"`
-			StateStatus *string `json:"stateStatus,omitempty"`
-		} `json:"variables,omitempty"`
-	} `json:"diff,omitempty"`
-	Errors *[]struct {
-		Fields  *[]string     `json:"fields,omitempty"`
-		Indexes *[]int        `json:"indexes,omitempty"`
-		Kind    *TemplateKind `json:"kind,omitempty"`
-		Reason  *string       `json:"reason,omitempty"`
-	} `json:"errors,omitempty"`
-	Sources *[]string `json:"sources,omitempty"`
-	StackID *string   `json:"stackID,omitempty"`
-	Summary *struct {
-		Buckets *[]struct {
-			Description       *string            `json:"description,omitempty"`
-			EnvReferences     *PkgEnvReferences  `json:"envReferences,omitempty"`
-			Id                *string            `json:"id,omitempty"`
-			LabelAssociations *[]PkgSummaryLabel `json:"labelAssociations,omitempty"`
-			Name              *string            `json:"name,omitempty"`
-			OrgID             *string            `json:"orgID,omitempty"`
-			PkgName           *string            `json:"pkgName,omitempty"`
-			RetentionPeriod   *int               `json:"retentionPeriod,omitempty"`
-		} `json:"buckets,omitempty"`
-		Checks *[]struct {
-			// Embedded struct due to allOf(#/components/schemas/CheckDiscriminator)
-			CheckDiscriminator
-			// Embedded fields due to inline allOf schema
-			EnvReferences     *PkgEnvReferences  `json:"envReferences,omitempty"`
-			LabelAssociations *[]PkgSummaryLabel `json:"labelAssociations,omitempty"`
-			PkgName           *string            `json:"pkgName,omitempty"`
-		} `json:"checks,omitempty"`
-		Dashboards *[]struct {
-			Charts            *[]PkgChart        `json:"charts,omitempty"`
-			Description       *string            `json:"description,omitempty"`
-			EnvReferences     *PkgEnvReferences  `json:"envReferences,omitempty"`
-			Id                *string            `json:"id,omitempty"`
-			LabelAssociations *[]PkgSummaryLabel `json:"labelAssociations,omitempty"`
-			Name              *string            `json:"name,omitempty"`
-			OrgID             *string            `json:"orgID,omitempty"`
-			PkgName           *string            `json:"pkgName,omitempty"`
-		} `json:"dashboards,omitempty"`
-		LabelMappings *[]struct {
-			LabelID         *string `json:"labelID,omitempty"`
-			LabelName       *string `json:"labelName,omitempty"`
-			LabelPkgName    *string `json:"labelPkgName,omitempty"`
-			ResourceID      *string `json:"resourceID,omitempty"`
-			ResourceName    *string `json:"resourceName,omitempty"`
-			ResourcePkgName *string `json:"resourcePkgName,omitempty"`
-			ResourceType    *string `json:"resourceType,omitempty"`
-			Status          *string `json:"status,omitempty"`
-		} `json:"labelMappings,omitempty"`
-		Labels                *[]PkgSummaryLabel `json:"labels,omitempty"`
-		MissingEnvRefs        *[]string          `json:"missingEnvRefs,omitempty"`
-		MissingSecrets        *[]string          `json:"missingSecrets,omitempty"`
-		NotificationEndpoints *[]struct {
-			// Embedded struct due to allOf(#/components/schemas/NotificationEndpointDiscrimator)
-			NotificationEndpointDiscrimator
-			// Embedded fields due to inline allOf schema
-			EnvReferences     *PkgEnvReferences  `json:"envReferences,omitempty"`
-			LabelAssociations *[]PkgSummaryLabel `json:"labelAssociations,omitempty"`
-			PkgName           *string            `json:"pkgName,omitempty"`
-		} `json:"notificationEndpoints,omitempty"`
-		NotificationRules *[]struct {
-			Description       *string            `json:"description,omitempty"`
-			EndpointID        *string            `json:"endpointID,omitempty"`
-			EndpointPkgName   *string            `json:"endpointPkgName,omitempty"`
-			EndpointType      *string            `json:"endpointType,omitempty"`
-			EnvReferences     *PkgEnvReferences  `json:"envReferences,omitempty"`
-			Every             *string            `json:"every,omitempty"`
-			LabelAssociations *[]PkgSummaryLabel `json:"labelAssociations,omitempty"`
-			MessageTemplate   *string            `json:"messageTemplate,omitempty"`
-			Name              *string            `json:"name,omitempty"`
-			Offset            *string            `json:"offset,omitempty"`
-			PkgName           *string            `json:"pkgName,omitempty"`
-			Status            *string            `json:"status,omitempty"`
-			StatusRules       *[]struct {
-				CurrentLevel  *string `json:"currentLevel,omitempty"`
-				PreviousLevel *string `json:"previousLevel,omitempty"`
-			} `json:"statusRules,omitempty"`
-			TagRules *[]struct {
-				Key      *string `json:"key,omitempty"`
-				Operator *string `json:"operator,omitempty"`
-				Value    *string `json:"value,omitempty"`
-			} `json:"tagRules,omitempty"`
-		} `json:"notificationRules,omitempty"`
-		Tasks *[]struct {
-			Cron          *string           `json:"cron,omitempty"`
-			Description   *string           `json:"description,omitempty"`
-			EnvReferences *PkgEnvReferences `json:"envReferences,omitempty"`
-			Every         *string           `json:"every,omitempty"`
-			Id            *string           `json:"id,omitempty"`
-			Name          *string           `json:"name,omitempty"`
-			Offset        *string           `json:"offset,omitempty"`
-			PkgName       *string           `json:"pkgName,omitempty"`
-			Query         *string           `json:"query,omitempty"`
-			Status        *string           `json:"status,omitempty"`
-		} `json:"tasks,omitempty"`
-		TelegrafConfigs *[]struct {
-			// Embedded struct due to allOf(#/components/schemas/TelegrafRequest)
-			TelegrafRequest
-			// Embedded fields due to inline allOf schema
-			EnvReferences     *PkgEnvReferences  `json:"envReferences,omitempty"`
-			LabelAssociations *[]PkgSummaryLabel `json:"labelAssociations,omitempty"`
-			PkgName           *string            `json:"pkgName,omitempty"`
-		} `json:"telegrafConfigs,omitempty"`
-		Variables *[]struct {
-			Arguments         *VariableProperties `json:"arguments,omitempty"`
-			Description       *string             `json:"description,omitempty"`
-			EnvReferences     *PkgEnvReferences   `json:"envReferences,omitempty"`
-			Id                *string             `json:"id,omitempty"`
-			LabelAssociations *[]PkgSummaryLabel  `json:"labelAssociations,omitempty"`
-			Name              *string             `json:"name,omitempty"`
-			OrgID             *string             `json:"orgID,omitempty"`
-			PkgName           *string             `json:"pkgName,omitempty"`
-		} `json:"variables,omitempty"`
-	} `json:"summary,omitempty"`
-}
-
-// PkgSummaryLabel defines model for PkgSummaryLabel.
-type PkgSummaryLabel struct {
-	EnvReferences *PkgEnvReferences `json:"envReferences,omitempty"`
-	Id            *string           `json:"id,omitempty"`
-	Name          *string           `json:"name,omitempty"`
-	OrgID         *string           `json:"orgID,omitempty"`
-	PkgName       *string           `json:"pkgName,omitempty"`
-	Properties    *struct {
-		Color       *string `json:"color,omitempty"`
-		Description *string `json:"description,omitempty"`
-	} `json:"properties,omitempty"`
-}
-
 // PostBucketRequest defines model for PostBucketRequest.
 type PostBucketRequest struct {
 	Description *string `json:"description,omitempty"`
 	Name        string  `json:"name"`
-	OrgID       *string `json:"orgID,omitempty"`
+	OrgID       string  `json:"orgID"`
 
 	// Rules to expire or retain data.  No rules means data never expires.
 	RetentionRules RetentionRules `json:"retentionRules"`
@@ -3543,24 +3207,30 @@ type Sources struct {
 
 // Stack defines model for Stack.
 type Stack struct {
-	CreatedAt   *time.Time `json:"createdAt,omitempty"`
-	Description *string    `json:"description,omitempty"`
-	Id          *string    `json:"id,omitempty"`
-	Name        *string    `json:"name,omitempty"`
-	OrgID       *string    `json:"orgID,omitempty"`
-	Resources   *[]struct {
-		ApiVersion   *string `json:"apiVersion,omitempty"`
-		Associations *[]struct {
-			Kind    *TemplateKind `json:"kind,omitempty"`
-			PkgName *string       `json:"pkgName,omitempty"`
-		} `json:"associations,omitempty"`
-		Kind       *TemplateKind `json:"kind,omitempty"`
-		PkgName    *string       `json:"pkgName,omitempty"`
-		ResourceID *string       `json:"resourceID,omitempty"`
-	} `json:"resources,omitempty"`
-	Sources   *[]string  `json:"sources,omitempty"`
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
-	Urls      *[]string  `json:"urls,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	Events    *[]struct {
+		Description *string `json:"description,omitempty"`
+		EventType   *string `json:"eventType,omitempty"`
+		Name        *string `json:"name,omitempty"`
+		Resources   *[]struct {
+			ApiVersion   *string `json:"apiVersion,omitempty"`
+			Associations *[]struct {
+				Kind     *TemplateKind `json:"kind,omitempty"`
+				MetaName *string       `json:"metaName,omitempty"`
+			} `json:"associations,omitempty"`
+			Kind  *TemplateKind `json:"kind,omitempty"`
+			Links *struct {
+				Self *string `json:"self,omitempty"`
+			} `json:"links,omitempty"`
+			ResourceID       *string `json:"resourceID,omitempty"`
+			TemplateMetaName *string `json:"templateMetaName,omitempty"`
+		} `json:"resources,omitempty"`
+		Sources   *[]string  `json:"sources,omitempty"`
+		UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+		Urls      *[]string  `json:"urls,omitempty"`
+	} `json:"events,omitempty"`
+	Id    *string `json:"id,omitempty"`
+	OrgID *string `json:"orgID,omitempty"`
 }
 
 // Statement defines model for Statement.
@@ -4171,8 +3841,406 @@ type Telegrafs struct {
 	Configurations *[]Telegraf `json:"configurations,omitempty"`
 }
 
+// Template defines model for Template.
+type Template []struct {
+	ApiVersion *string       `json:"apiVersion,omitempty"`
+	Kind       *TemplateKind `json:"kind,omitempty"`
+	Meta       *struct {
+		Name *string `json:"name,omitempty"`
+	} `json:"meta,omitempty"`
+	Spec *map[string]interface{} `json:"spec,omitempty"`
+}
+
+// TemplateApply defines model for TemplateApply.
+type TemplateApply struct {
+	Actions *[]interface{}         `json:"actions,omitempty"`
+	DryRun  *bool                  `json:"dryRun,omitempty"`
+	EnvRefs *TemplateApply_EnvRefs `json:"envRefs,omitempty"`
+	OrgID   *string                `json:"orgID,omitempty"`
+	Remotes *[]struct {
+		ContentType *string `json:"contentType,omitempty"`
+		Url         string  `json:"url"`
+	} `json:"remotes,omitempty"`
+	Secrets  *TemplateApply_Secrets `json:"secrets,omitempty"`
+	StackID  *string                `json:"stackID,omitempty"`
+	Template *struct {
+		ContentType *string   `json:"contentType,omitempty"`
+		Contents    *Template `json:"contents,omitempty"`
+		Sources     *[]string `json:"sources,omitempty"`
+	} `json:"template,omitempty"`
+	Templates *[]struct {
+		ContentType *string   `json:"contentType,omitempty"`
+		Contents    *Template `json:"contents,omitempty"`
+		Sources     *[]string `json:"sources,omitempty"`
+	} `json:"templates,omitempty"`
+}
+
+// TemplateApply_EnvRefs defines model for TemplateApply.EnvRefs.
+type TemplateApply_EnvRefs struct {
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// TemplateApply_Secrets defines model for TemplateApply.Secrets.
+type TemplateApply_Secrets struct {
+	AdditionalProperties map[string]string `json:"-"`
+}
+
+// TemplateChart defines model for TemplateChart.
+type TemplateChart struct {
+	Height     *int            `json:"height,omitempty"`
+	Properties *ViewProperties `json:"properties,omitempty"`
+	Width      *int            `json:"width,omitempty"`
+	XPos       *int            `json:"xPos,omitempty"`
+	YPos       *int            `json:"yPos,omitempty"`
+}
+
+// TemplateEnvReferences defines model for TemplateEnvReferences.
+type TemplateEnvReferences []struct {
+
+	// Default value that will be provided for the reference when no value is provided
+	DefaultValue *interface{} `json:"defaultValue,omitempty"`
+
+	// Key identified as environment reference and is the key identified in the template
+	EnvRefKey string `json:"envRefKey"`
+
+	// Field the environment reference corresponds too
+	ResourceField string `json:"resourceField"`
+
+	// Value provided to fulfill reference
+	Value *interface{} `json:"value,omitempty"`
+}
+
+// TemplateExport defines model for TemplateExport.
+type TemplateExport struct {
+	OrgIDs *[]struct {
+		OrgID           *string `json:"orgID,omitempty"`
+		ResourceFilters *struct {
+			ByLabel        *[]string       `json:"byLabel,omitempty"`
+			ByResourceKind *[]TemplateKind `json:"byResourceKind,omitempty"`
+		} `json:"resourceFilters,omitempty"`
+	} `json:"orgIDs,omitempty"`
+	Resources *struct {
+		Id   string       `json:"id"`
+		Kind TemplateKind `json:"kind"`
+		Name *string      `json:"name,omitempty"`
+	} `json:"resources,omitempty"`
+	StackID *string `json:"stackID,omitempty"`
+}
+
 // TemplateKind defines model for TemplateKind.
 type TemplateKind string
+
+// TemplateSummary defines model for TemplateSummary.
+type TemplateSummary struct {
+	Diff *struct {
+		Buckets *[]struct {
+			Id   *string       `json:"id,omitempty"`
+			Kind *TemplateKind `json:"kind,omitempty"`
+			New  *struct {
+				Description *string `json:"description,omitempty"`
+				Name        *string `json:"name,omitempty"`
+
+				// Rules to expire or retain data.  No rules means data never expires.
+				RetentionRules *RetentionRules `json:"retentionRules,omitempty"`
+			} `json:"new,omitempty"`
+			Old *struct {
+				Description *string `json:"description,omitempty"`
+				Name        *string `json:"name,omitempty"`
+
+				// Rules to expire or retain data.  No rules means data never expires.
+				RetentionRules *RetentionRules `json:"retentionRules,omitempty"`
+			} `json:"old,omitempty"`
+			StateStatus      *string `json:"stateStatus,omitempty"`
+			TemplateMetaName *string `json:"templateMetaName,omitempty"`
+		} `json:"buckets,omitempty"`
+		Checks *[]struct {
+			Id               *string             `json:"id,omitempty"`
+			Kind             *TemplateKind       `json:"kind,omitempty"`
+			New              *CheckDiscriminator `json:"new,omitempty"`
+			Old              *CheckDiscriminator `json:"old,omitempty"`
+			StateStatus      *string             `json:"stateStatus,omitempty"`
+			TemplateMetaName *string             `json:"templateMetaName,omitempty"`
+		} `json:"checks,omitempty"`
+		Dashboards *[]struct {
+			Id   *string       `json:"id,omitempty"`
+			Kind *TemplateKind `json:"kind,omitempty"`
+			New  *struct {
+				Charts      *[]TemplateChart `json:"charts,omitempty"`
+				Description *string          `json:"description,omitempty"`
+				Name        *string          `json:"name,omitempty"`
+			} `json:"new,omitempty"`
+			Old *struct {
+				Charts      *[]TemplateChart `json:"charts,omitempty"`
+				Description *string          `json:"description,omitempty"`
+				Name        *string          `json:"name,omitempty"`
+			} `json:"old,omitempty"`
+			StateStatus      *string `json:"stateStatus,omitempty"`
+			TemplateMetaName *string `json:"templateMetaName,omitempty"`
+		} `json:"dashboards,omitempty"`
+		LabelMappings *[]struct {
+			LabelID                  *string `json:"labelID,omitempty"`
+			LabelName                *string `json:"labelName,omitempty"`
+			LabelTemplateMetaName    *string `json:"labelTemplateMetaName,omitempty"`
+			ResourceID               *string `json:"resourceID,omitempty"`
+			ResourceName             *string `json:"resourceName,omitempty"`
+			ResourceTemplateMetaName *string `json:"resourceTemplateMetaName,omitempty"`
+			ResourceType             *string `json:"resourceType,omitempty"`
+			Status                   *string `json:"status,omitempty"`
+		} `json:"labelMappings,omitempty"`
+		Labels *[]struct {
+			Id   *string       `json:"id,omitempty"`
+			Kind *TemplateKind `json:"kind,omitempty"`
+			New  *struct {
+				Color       *string `json:"color,omitempty"`
+				Description *string `json:"description,omitempty"`
+				Name        *string `json:"name,omitempty"`
+			} `json:"new,omitempty"`
+			Old *struct {
+				Color       *string `json:"color,omitempty"`
+				Description *string `json:"description,omitempty"`
+				Name        *string `json:"name,omitempty"`
+			} `json:"old,omitempty"`
+			StateStatus      *string `json:"stateStatus,omitempty"`
+			TemplateMetaName *string `json:"templateMetaName,omitempty"`
+		} `json:"labels,omitempty"`
+		NotificationEndpoints *[]struct {
+			Id               *string                          `json:"id,omitempty"`
+			Kind             *TemplateKind                    `json:"kind,omitempty"`
+			New              *NotificationEndpointDiscrimator `json:"new,omitempty"`
+			Old              *NotificationEndpointDiscrimator `json:"old,omitempty"`
+			StateStatus      *string                          `json:"stateStatus,omitempty"`
+			TemplateMetaName *string                          `json:"templateMetaName,omitempty"`
+		} `json:"notificationEndpoints,omitempty"`
+		NotificationRules *[]struct {
+			Id   *string       `json:"id,omitempty"`
+			Kind *TemplateKind `json:"kind,omitempty"`
+			New  *struct {
+				Description     *string `json:"description,omitempty"`
+				EndpointID      *string `json:"endpointID,omitempty"`
+				EndpointName    *string `json:"endpointName,omitempty"`
+				EndpointType    *string `json:"endpointType,omitempty"`
+				Every           *string `json:"every,omitempty"`
+				MessageTemplate *string `json:"messageTemplate,omitempty"`
+				Name            *string `json:"name,omitempty"`
+				Offset          *string `json:"offset,omitempty"`
+				Status          *string `json:"status,omitempty"`
+				StatusRules     *[]struct {
+					CurrentLevel  *string `json:"currentLevel,omitempty"`
+					PreviousLevel *string `json:"previousLevel,omitempty"`
+				} `json:"statusRules,omitempty"`
+				TagRules *[]struct {
+					Key      *string `json:"key,omitempty"`
+					Operator *string `json:"operator,omitempty"`
+					Value    *string `json:"value,omitempty"`
+				} `json:"tagRules,omitempty"`
+			} `json:"new,omitempty"`
+			Old *struct {
+				Description     *string `json:"description,omitempty"`
+				EndpointID      *string `json:"endpointID,omitempty"`
+				EndpointName    *string `json:"endpointName,omitempty"`
+				EndpointType    *string `json:"endpointType,omitempty"`
+				Every           *string `json:"every,omitempty"`
+				MessageTemplate *string `json:"messageTemplate,omitempty"`
+				Name            *string `json:"name,omitempty"`
+				Offset          *string `json:"offset,omitempty"`
+				Status          *string `json:"status,omitempty"`
+				StatusRules     *[]struct {
+					CurrentLevel  *string `json:"currentLevel,omitempty"`
+					PreviousLevel *string `json:"previousLevel,omitempty"`
+				} `json:"statusRules,omitempty"`
+				TagRules *[]struct {
+					Key      *string `json:"key,omitempty"`
+					Operator *string `json:"operator,omitempty"`
+					Value    *string `json:"value,omitempty"`
+				} `json:"tagRules,omitempty"`
+			} `json:"old,omitempty"`
+			StateStatus      *string `json:"stateStatus,omitempty"`
+			TemplateMetaName *string `json:"templateMetaName,omitempty"`
+		} `json:"notificationRules,omitempty"`
+		Tasks *[]struct {
+			Id   *string       `json:"id,omitempty"`
+			Kind *TemplateKind `json:"kind,omitempty"`
+			New  *struct {
+				Cron        *string `json:"cron,omitempty"`
+				Description *string `json:"description,omitempty"`
+				Every       *string `json:"every,omitempty"`
+				Name        *string `json:"name,omitempty"`
+				Offset      *string `json:"offset,omitempty"`
+				Query       *string `json:"query,omitempty"`
+				Status      *string `json:"status,omitempty"`
+			} `json:"new,omitempty"`
+			Old *struct {
+				Cron        *string `json:"cron,omitempty"`
+				Description *string `json:"description,omitempty"`
+				Every       *string `json:"every,omitempty"`
+				Name        *string `json:"name,omitempty"`
+				Offset      *string `json:"offset,omitempty"`
+				Query       *string `json:"query,omitempty"`
+				Status      *string `json:"status,omitempty"`
+			} `json:"old,omitempty"`
+			StateStatus      *string `json:"stateStatus,omitempty"`
+			TemplateMetaName *string `json:"templateMetaName,omitempty"`
+		} `json:"tasks,omitempty"`
+		TelegrafConfigs *[]struct {
+			Id               *string          `json:"id,omitempty"`
+			Kind             *TemplateKind    `json:"kind,omitempty"`
+			New              *TelegrafRequest `json:"new,omitempty"`
+			Old              *TelegrafRequest `json:"old,omitempty"`
+			StateStatus      *string          `json:"stateStatus,omitempty"`
+			TemplateMetaName *string          `json:"templateMetaName,omitempty"`
+		} `json:"telegrafConfigs,omitempty"`
+		Variables *[]struct {
+			Id   *string       `json:"id,omitempty"`
+			Kind *TemplateKind `json:"kind,omitempty"`
+			New  *struct {
+				Args        *VariableProperties `json:"args,omitempty"`
+				Description *string             `json:"description,omitempty"`
+				Name        *string             `json:"name,omitempty"`
+			} `json:"new,omitempty"`
+			Old *struct {
+				Args        *VariableProperties `json:"args,omitempty"`
+				Description *string             `json:"description,omitempty"`
+				Name        *string             `json:"name,omitempty"`
+			} `json:"old,omitempty"`
+			StateStatus      *string `json:"stateStatus,omitempty"`
+			TemplateMetaName *string `json:"templateMetaName,omitempty"`
+		} `json:"variables,omitempty"`
+	} `json:"diff,omitempty"`
+	Errors *[]struct {
+		Fields  *[]string     `json:"fields,omitempty"`
+		Indexes *[]int        `json:"indexes,omitempty"`
+		Kind    *TemplateKind `json:"kind,omitempty"`
+		Reason  *string       `json:"reason,omitempty"`
+	} `json:"errors,omitempty"`
+	Sources *[]string `json:"sources,omitempty"`
+	StackID *string   `json:"stackID,omitempty"`
+	Summary *struct {
+		Buckets *[]struct {
+			Description       *string                 `json:"description,omitempty"`
+			EnvReferences     *TemplateEnvReferences  `json:"envReferences,omitempty"`
+			Id                *string                 `json:"id,omitempty"`
+			Kind              *TemplateKind           `json:"kind,omitempty"`
+			LabelAssociations *[]TemplateSummaryLabel `json:"labelAssociations,omitempty"`
+			Name              *string                 `json:"name,omitempty"`
+			OrgID             *string                 `json:"orgID,omitempty"`
+			RetentionPeriod   *int                    `json:"retentionPeriod,omitempty"`
+			TemplateMetaName  *string                 `json:"templateMetaName,omitempty"`
+		} `json:"buckets,omitempty"`
+		Checks *[]struct {
+			// Embedded struct due to allOf(#/components/schemas/CheckDiscriminator)
+			CheckDiscriminator
+			// Embedded fields due to inline allOf schema
+			EnvReferences     *TemplateEnvReferences  `json:"envReferences,omitempty"`
+			Kind              *TemplateKind           `json:"kind,omitempty"`
+			LabelAssociations *[]TemplateSummaryLabel `json:"labelAssociations,omitempty"`
+			TemplateMetaName  *string                 `json:"templateMetaName,omitempty"`
+		} `json:"checks,omitempty"`
+		Dashboards *[]struct {
+			Charts            *[]TemplateChart        `json:"charts,omitempty"`
+			Description       *string                 `json:"description,omitempty"`
+			EnvReferences     *TemplateEnvReferences  `json:"envReferences,omitempty"`
+			Id                *string                 `json:"id,omitempty"`
+			Kind              *TemplateKind           `json:"kind,omitempty"`
+			LabelAssociations *[]TemplateSummaryLabel `json:"labelAssociations,omitempty"`
+			Name              *string                 `json:"name,omitempty"`
+			OrgID             *string                 `json:"orgID,omitempty"`
+			TemplateMetaName  *string                 `json:"templateMetaName,omitempty"`
+		} `json:"dashboards,omitempty"`
+		LabelMappings *[]struct {
+			LabelID                  *string `json:"labelID,omitempty"`
+			LabelName                *string `json:"labelName,omitempty"`
+			LabelTemplateMetaName    *string `json:"labelTemplateMetaName,omitempty"`
+			ResourceID               *string `json:"resourceID,omitempty"`
+			ResourceName             *string `json:"resourceName,omitempty"`
+			ResourceTemplateMetaName *string `json:"resourceTemplateMetaName,omitempty"`
+			ResourceType             *string `json:"resourceType,omitempty"`
+			Status                   *string `json:"status,omitempty"`
+		} `json:"labelMappings,omitempty"`
+		Labels                *[]TemplateSummaryLabel `json:"labels,omitempty"`
+		MissingEnvRefs        *[]string               `json:"missingEnvRefs,omitempty"`
+		MissingSecrets        *[]string               `json:"missingSecrets,omitempty"`
+		NotificationEndpoints *[]struct {
+			// Embedded struct due to allOf(#/components/schemas/NotificationEndpointDiscrimator)
+			NotificationEndpointDiscrimator
+			// Embedded fields due to inline allOf schema
+			EnvReferences     *TemplateEnvReferences  `json:"envReferences,omitempty"`
+			Kind              *TemplateKind           `json:"kind,omitempty"`
+			LabelAssociations *[]TemplateSummaryLabel `json:"labelAssociations,omitempty"`
+			TemplateMetaName  *string                 `json:"templateMetaName,omitempty"`
+		} `json:"notificationEndpoints,omitempty"`
+		NotificationRules *[]struct {
+			Description              *string                 `json:"description,omitempty"`
+			EndpointID               *string                 `json:"endpointID,omitempty"`
+			EndpointTemplateMetaName *string                 `json:"endpointTemplateMetaName,omitempty"`
+			EndpointType             *string                 `json:"endpointType,omitempty"`
+			EnvReferences            *TemplateEnvReferences  `json:"envReferences,omitempty"`
+			Every                    *string                 `json:"every,omitempty"`
+			Kind                     *TemplateKind           `json:"kind,omitempty"`
+			LabelAssociations        *[]TemplateSummaryLabel `json:"labelAssociations,omitempty"`
+			MessageTemplate          *string                 `json:"messageTemplate,omitempty"`
+			Name                     *string                 `json:"name,omitempty"`
+			Offset                   *string                 `json:"offset,omitempty"`
+			Status                   *string                 `json:"status,omitempty"`
+			StatusRules              *[]struct {
+				CurrentLevel  *string `json:"currentLevel,omitempty"`
+				PreviousLevel *string `json:"previousLevel,omitempty"`
+			} `json:"statusRules,omitempty"`
+			TagRules *[]struct {
+				Key      *string `json:"key,omitempty"`
+				Operator *string `json:"operator,omitempty"`
+				Value    *string `json:"value,omitempty"`
+			} `json:"tagRules,omitempty"`
+			TemplateMetaName *string `json:"templateMetaName,omitempty"`
+		} `json:"notificationRules,omitempty"`
+		Tasks *[]struct {
+			Cron             *string                `json:"cron,omitempty"`
+			Description      *string                `json:"description,omitempty"`
+			EnvReferences    *TemplateEnvReferences `json:"envReferences,omitempty"`
+			Every            *string                `json:"every,omitempty"`
+			Id               *string                `json:"id,omitempty"`
+			Kind             *TemplateKind          `json:"kind,omitempty"`
+			Name             *string                `json:"name,omitempty"`
+			Offset           *string                `json:"offset,omitempty"`
+			Query            *string                `json:"query,omitempty"`
+			Status           *string                `json:"status,omitempty"`
+			TemplateMetaName *string                `json:"templateMetaName,omitempty"`
+		} `json:"tasks,omitempty"`
+		TelegrafConfigs *[]struct {
+			// Embedded struct due to allOf(#/components/schemas/TelegrafRequest)
+			TelegrafRequest
+			// Embedded fields due to inline allOf schema
+			EnvReferences     *TemplateEnvReferences  `json:"envReferences,omitempty"`
+			Kind              *TemplateKind           `json:"kind,omitempty"`
+			LabelAssociations *[]TemplateSummaryLabel `json:"labelAssociations,omitempty"`
+			TemplateMetaName  *string                 `json:"templateMetaName,omitempty"`
+		} `json:"telegrafConfigs,omitempty"`
+		Variables *[]struct {
+			Arguments         *VariableProperties     `json:"arguments,omitempty"`
+			Description       *string                 `json:"description,omitempty"`
+			EnvReferences     *TemplateEnvReferences  `json:"envReferences,omitempty"`
+			Id                *string                 `json:"id,omitempty"`
+			Kind              *TemplateKind           `json:"kind,omitempty"`
+			LabelAssociations *[]TemplateSummaryLabel `json:"labelAssociations,omitempty"`
+			Name              *string                 `json:"name,omitempty"`
+			OrgID             *string                 `json:"orgID,omitempty"`
+			TemplateMetaName  *string                 `json:"templateMetaName,omitempty"`
+		} `json:"variables,omitempty"`
+	} `json:"summary,omitempty"`
+}
+
+// TemplateSummaryLabel defines model for TemplateSummaryLabel.
+type TemplateSummaryLabel struct {
+	EnvReferences *TemplateEnvReferences `json:"envReferences,omitempty"`
+	Id            *string                `json:"id,omitempty"`
+	Kind          *TemplateKind          `json:"kind,omitempty"`
+	Name          *string                `json:"name,omitempty"`
+	OrgID         *string                `json:"orgID,omitempty"`
+	Properties    *struct {
+		Color       *string `json:"color,omitempty"`
+		Description *string `json:"description,omitempty"`
+	} `json:"properties,omitempty"`
+	TemplateMetaName *string `json:"templateMetaName,omitempty"`
+}
 
 // TestStatement defines model for TestStatement.
 type TestStatement struct {
@@ -4336,8 +4404,9 @@ type XYViewProperties struct {
 	Axes Axes `json:"axes"`
 
 	// Colors define color encoding of data into a visualization
-	Colors []DashboardColor `json:"colors"`
-	Geom   XYGeom           `json:"geom"`
+	Colors         []DashboardColor                `json:"colors"`
+	Geom           XYGeom                          `json:"geom"`
+	HoverDimension *XYViewPropertiesHoverDimension `json:"hoverDimension,omitempty"`
 
 	// Legend define encoding of data into a view's legend
 	Legend     Legend                   `json:"legend"`
@@ -4354,6 +4423,9 @@ type XYViewProperties struct {
 	XColumn           *string              `json:"xColumn,omitempty"`
 	YColumn           *string              `json:"yColumn,omitempty"`
 }
+
+// XYViewPropertiesHoverDimension defines model for XYViewProperties.HoverDimension.
+type XYViewPropertiesHoverDimension string
 
 // XYViewPropertiesPosition defines model for XYViewProperties.Position.
 type XYViewPropertiesPosition string
@@ -4652,7 +4724,7 @@ type GetDashboardsParams struct {
 	// The column to sort by.
 	SortBy *GetDashboardsParamsSortBy `json:"sortBy,omitempty"`
 
-	// List of dashboard IDs to return. If both `id and `owner` are specified, only `id` is used.
+	// List of dashboard IDs to return. If both `id` and `owner` are specified, only `id` is used.
 	Id *[]string `json:"id,omitempty"`
 
 	// The organization ID.
@@ -5280,54 +5352,6 @@ type PatchOrgsIDParams struct {
 	ZapTraceSpan *TraceSpan `json:"Zap-Trace-Span,omitempty"`
 }
 
-// PostOrgsIDInvitesJSONBody defines parameters for PostOrgsIDInvites.
-type PostOrgsIDInvitesJSONBody Invite
-
-// PostOrgsIDInvitesParams defines parameters for PostOrgsIDInvites.
-type PostOrgsIDInvitesParams struct {
-
-	// OpenTracing span context
-	ZapTraceSpan *TraceSpan `json:"Zap-Trace-Span,omitempty"`
-}
-
-// DeleteOrgsIDInviteIDParams defines parameters for DeleteOrgsIDInviteID.
-type DeleteOrgsIDInviteIDParams struct {
-
-	// OpenTracing span context
-	ZapTraceSpan *TraceSpan `json:"Zap-Trace-Span,omitempty"`
-}
-
-// PostOrgsIDInviteIDParams defines parameters for PostOrgsIDInviteID.
-type PostOrgsIDInviteIDParams struct {
-
-	// OpenTracing span context
-	ZapTraceSpan *TraceSpan `json:"Zap-Trace-Span,omitempty"`
-}
-
-// GetOrgsIDLabelsParams defines parameters for GetOrgsIDLabels.
-type GetOrgsIDLabelsParams struct {
-
-	// OpenTracing span context
-	ZapTraceSpan *TraceSpan `json:"Zap-Trace-Span,omitempty"`
-}
-
-// PostOrgsIDLabelsJSONBody defines parameters for PostOrgsIDLabels.
-type PostOrgsIDLabelsJSONBody LabelMapping
-
-// PostOrgsIDLabelsParams defines parameters for PostOrgsIDLabels.
-type PostOrgsIDLabelsParams struct {
-
-	// OpenTracing span context
-	ZapTraceSpan *TraceSpan `json:"Zap-Trace-Span,omitempty"`
-}
-
-// DeleteOrgsIDLabelsIDParams defines parameters for DeleteOrgsIDLabelsID.
-type DeleteOrgsIDLabelsIDParams struct {
-
-	// OpenTracing span context
-	ZapTraceSpan *TraceSpan `json:"Zap-Trace-Span,omitempty"`
-}
-
 // GetOrgsIDMembersParams defines parameters for GetOrgsIDMembers.
 type GetOrgsIDMembersParams struct {
 
@@ -5401,68 +5425,6 @@ type PostOrgsIDSecretsParams struct {
 
 	// OpenTracing span context
 	ZapTraceSpan *TraceSpan `json:"Zap-Trace-Span,omitempty"`
-}
-
-// GetCloudUsersParams defines parameters for GetCloudUsers.
-type GetCloudUsersParams struct {
-
-	// OpenTracing span context
-	ZapTraceSpan *TraceSpan `json:"Zap-Trace-Span,omitempty"`
-}
-
-// DeleteOrgsIDCloudUserIDParams defines parameters for DeleteOrgsIDCloudUserID.
-type DeleteOrgsIDCloudUserIDParams struct {
-
-	// OpenTracing span context
-	ZapTraceSpan *TraceSpan `json:"Zap-Trace-Span,omitempty"`
-}
-
-// CreatePkgJSONBody defines parameters for CreatePkg.
-type CreatePkgJSONBody PkgCreate
-
-// ApplyPkgJSONBody defines parameters for ApplyPkg.
-type ApplyPkgJSONBody PkgApply
-
-// ListStacksParams defines parameters for ListStacks.
-type ListStacksParams struct {
-
-	// The organization id of the stacks
-	OrgID string `json:"orgID"`
-
-	// A collection of names to filter the list by.
-	Name *string `json:"name,omitempty"`
-
-	// A collection of stackIDs to filter the list by.
-	StackID *string `json:"stackID,omitempty"`
-}
-
-// CreateStackJSONBody defines parameters for CreateStack.
-type CreateStackJSONBody struct {
-	Description *string   `json:"description,omitempty"`
-	Name        *string   `json:"name,omitempty"`
-	OrgID       *string   `json:"orgID,omitempty"`
-	Urls        *[]string `json:"urls,omitempty"`
-}
-
-// DeleteStackParams defines parameters for DeleteStack.
-type DeleteStackParams struct {
-
-	// The organization id of the user
-	OrgID string `json:"orgID"`
-}
-
-// UpdateStackJSONBody defines parameters for UpdateStack.
-type UpdateStackJSONBody struct {
-	Description *string   `json:"description,omitempty"`
-	Name        *string   `json:"name,omitempty"`
-	Urls        *[]string `json:"urls,omitempty"`
-}
-
-// ExportStackParams defines parameters for ExportStack.
-type ExportStackParams struct {
-
-	// The organization id of the user
-	OrgID string `json:"orgID"`
 }
 
 // PostQueryJSONBody defines parameters for PostQuery.
@@ -5775,6 +5737,46 @@ type GetSourcesIDHealthParams struct {
 
 	// OpenTracing span context
 	ZapTraceSpan *TraceSpan `json:"Zap-Trace-Span,omitempty"`
+}
+
+// ListStacksParams defines parameters for ListStacks.
+type ListStacksParams struct {
+
+	// The organization id of the stacks
+	OrgID string `json:"orgID"`
+
+	// A collection of names to filter the list by.
+	Name *string `json:"name,omitempty"`
+
+	// A collection of stackIDs to filter the list by.
+	StackID *string `json:"stackID,omitempty"`
+}
+
+// CreateStackJSONBody defines parameters for CreateStack.
+type CreateStackJSONBody struct {
+	Description *string   `json:"description,omitempty"`
+	Name        *string   `json:"name,omitempty"`
+	OrgID       *string   `json:"orgID,omitempty"`
+	Urls        *[]string `json:"urls,omitempty"`
+}
+
+// DeleteStackParams defines parameters for DeleteStack.
+type DeleteStackParams struct {
+
+	// The organization id of the user
+	OrgID string `json:"orgID"`
+}
+
+// UpdateStackJSONBody defines parameters for UpdateStack.
+type UpdateStackJSONBody struct {
+	AdditionalResources *[]struct {
+		Kind             string  `json:"kind"`
+		ResourceID       string  `json:"resourceID"`
+		TemplateMetaName *string `json:"templateMetaName,omitempty"`
+	} `json:"additionalResources,omitempty"`
+	Description  *string   `json:"description,omitempty"`
+	Name         *string   `json:"name,omitempty"`
+	TemplateURLs *[]string `json:"templateURLs,omitempty"`
 }
 
 // GetTasksParams defines parameters for GetTasks.
@@ -6108,6 +6110,12 @@ type DeleteTelegrafsIDOwnersIDParams struct {
 	ZapTraceSpan *TraceSpan `json:"Zap-Trace-Span,omitempty"`
 }
 
+// ApplyTemplateJSONBody defines parameters for ApplyTemplate.
+type ApplyTemplateJSONBody TemplateApply
+
+// ExportTemplateJSONBody defines parameters for ExportTemplate.
+type ExportTemplateJSONBody TemplateExport
+
 // GetUsersParams defines parameters for GetUsers.
 type GetUsersParams struct {
 
@@ -6397,12 +6405,6 @@ type PostOrgsJSONRequestBody PostOrgsJSONBody
 // PatchOrgsIDRequestBody defines body for PatchOrgsID for application/json ContentType.
 type PatchOrgsIDJSONRequestBody PatchOrgsIDJSONBody
 
-// PostOrgsIDInvitesRequestBody defines body for PostOrgsIDInvites for application/json ContentType.
-type PostOrgsIDInvitesJSONRequestBody PostOrgsIDInvitesJSONBody
-
-// PostOrgsIDLabelsRequestBody defines body for PostOrgsIDLabels for application/json ContentType.
-type PostOrgsIDLabelsJSONRequestBody PostOrgsIDLabelsJSONBody
-
 // PostOrgsIDMembersRequestBody defines body for PostOrgsIDMembers for application/json ContentType.
 type PostOrgsIDMembersJSONRequestBody PostOrgsIDMembersJSONBody
 
@@ -6414,18 +6416,6 @@ type PatchOrgsIDSecretsJSONRequestBody PatchOrgsIDSecretsJSONBody
 
 // PostOrgsIDSecretsRequestBody defines body for PostOrgsIDSecrets for application/json ContentType.
 type PostOrgsIDSecretsJSONRequestBody PostOrgsIDSecretsJSONBody
-
-// CreatePkgRequestBody defines body for CreatePkg for application/json ContentType.
-type CreatePkgJSONRequestBody CreatePkgJSONBody
-
-// ApplyPkgRequestBody defines body for ApplyPkg for application/json ContentType.
-type ApplyPkgJSONRequestBody ApplyPkgJSONBody
-
-// CreateStackRequestBody defines body for CreateStack for application/json ContentType.
-type CreateStackJSONRequestBody CreateStackJSONBody
-
-// UpdateStackRequestBody defines body for UpdateStack for application/json ContentType.
-type UpdateStackJSONRequestBody UpdateStackJSONBody
 
 // PostQueryRequestBody defines body for PostQuery for application/json ContentType.
 type PostQueryJSONRequestBody PostQueryJSONBody
@@ -6466,6 +6456,12 @@ type PostSourcesJSONRequestBody PostSourcesJSONBody
 // PatchSourcesIDRequestBody defines body for PatchSourcesID for application/json ContentType.
 type PatchSourcesIDJSONRequestBody PatchSourcesIDJSONBody
 
+// CreateStackRequestBody defines body for CreateStack for application/json ContentType.
+type CreateStackJSONRequestBody CreateStackJSONBody
+
+// UpdateStackRequestBody defines body for UpdateStack for application/json ContentType.
+type UpdateStackJSONRequestBody UpdateStackJSONBody
+
 // PostTasksRequestBody defines body for PostTasks for application/json ContentType.
 type PostTasksJSONRequestBody PostTasksJSONBody
 
@@ -6498,6 +6494,12 @@ type PostTelegrafsIDMembersJSONRequestBody PostTelegrafsIDMembersJSONBody
 
 // PostTelegrafsIDOwnersRequestBody defines body for PostTelegrafsIDOwners for application/json ContentType.
 type PostTelegrafsIDOwnersJSONRequestBody PostTelegrafsIDOwnersJSONBody
+
+// ApplyTemplateRequestBody defines body for ApplyTemplate for application/json ContentType.
+type ApplyTemplateJSONRequestBody ApplyTemplateJSONBody
+
+// ExportTemplateRequestBody defines body for ExportTemplate for application/json ContentType.
+type ExportTemplateJSONRequestBody ExportTemplateJSONBody
 
 // PostUsersRequestBody defines body for PostUsers for application/json ContentType.
 type PostUsersJSONRequestBody PostUsersJSONBody
@@ -6891,59 +6893,6 @@ func (a MapVariableProperties_Values) MarshalJSON() ([]byte, error) {
 	return json.Marshal(object)
 }
 
-// Getter for additional properties for PkgApply_Secrets. Returns the specified
-// element and whether it was found
-func (a PkgApply_Secrets) Get(fieldName string) (value string, found bool) {
-	if a.AdditionalProperties != nil {
-		value, found = a.AdditionalProperties[fieldName]
-	}
-	return
-}
-
-// Setter for additional properties for PkgApply_Secrets
-func (a *PkgApply_Secrets) Set(fieldName string, value string) {
-	if a.AdditionalProperties == nil {
-		a.AdditionalProperties = make(map[string]string)
-	}
-	a.AdditionalProperties[fieldName] = value
-}
-
-// Override default JSON handling for PkgApply_Secrets to handle AdditionalProperties
-func (a *PkgApply_Secrets) UnmarshalJSON(b []byte) error {
-	object := make(map[string]json.RawMessage)
-	err := json.Unmarshal(b, &object)
-	if err != nil {
-		return err
-	}
-
-	if len(object) != 0 {
-		a.AdditionalProperties = make(map[string]string)
-		for fieldName, fieldBuf := range object {
-			var fieldVal string
-			err := json.Unmarshal(fieldBuf, &fieldVal)
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
-			}
-			a.AdditionalProperties[fieldName] = fieldVal
-		}
-	}
-	return nil
-}
-
-// Override default JSON handling for PkgApply_Secrets to handle AdditionalProperties
-func (a PkgApply_Secrets) MarshalJSON() ([]byte, error) {
-	var err error
-	object := make(map[string]json.RawMessage)
-
-	for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = json.Marshal(field)
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
-		}
-	}
-	return json.Marshal(object)
-}
-
 // Getter for additional properties for Secrets. Returns the specified
 // element and whether it was found
 func (a Secrets) Get(fieldName string) (value string, found bool) {
@@ -6985,6 +6934,112 @@ func (a *Secrets) UnmarshalJSON(b []byte) error {
 
 // Override default JSON handling for Secrets to handle AdditionalProperties
 func (a Secrets) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+		}
+	}
+	return json.Marshal(object)
+}
+
+// Getter for additional properties for TemplateApply_EnvRefs. Returns the specified
+// element and whether it was found
+func (a TemplateApply_EnvRefs) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for TemplateApply_EnvRefs
+func (a *TemplateApply_EnvRefs) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for TemplateApply_EnvRefs to handle AdditionalProperties
+func (a *TemplateApply_EnvRefs) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for TemplateApply_EnvRefs to handle AdditionalProperties
+func (a TemplateApply_EnvRefs) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+		}
+	}
+	return json.Marshal(object)
+}
+
+// Getter for additional properties for TemplateApply_Secrets. Returns the specified
+// element and whether it was found
+func (a TemplateApply_Secrets) Get(fieldName string) (value string, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for TemplateApply_Secrets
+func (a *TemplateApply_Secrets) Set(fieldName string, value string) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]string)
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for TemplateApply_Secrets to handle AdditionalProperties
+func (a *TemplateApply_Secrets) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]string)
+		for fieldName, fieldBuf := range object {
+			var fieldVal string
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for TemplateApply_Secrets to handle AdditionalProperties
+func (a TemplateApply_Secrets) MarshalJSON() ([]byte, error) {
 	var err error
 	object := make(map[string]json.RawMessage)
 


### PR DESCRIPTION
Synced with the latest (beta 16) swagger.  Notably, removed orgs labels API cause it has been removed from the server API

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

