### PR TITLE
fix:  WriteAPIs management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Breaking changes
 1. [#173](https://github.com/influxdata/influxdb-client-go/pull/173) Removed deprecated API.
 1. [#174](https://github.com/influxdata/influxdb-client-go/pull/174) Removed orgs labels API cause [it has been removed from the server API](https://github.com/influxdata/influxdb/pull/19104)
+1. [#175](https://github.com/influxdata/influxdb-client-go/pull/175) Removed WriteAPI.Close()
 
 ### Features
 1. [#165](https://github.com/influxdata/influxdb-client-go/pull/165) Allow overriding the http.Client for the http service.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Features
 1. [#165](https://github.com/influxdata/influxdb-client-go/pull/165) Allow overriding the http.Client for the http service.
 
+### Bug fixes 
+1. [#175](https://github.com/influxdata/influxdb-client-go/pull/175) Fixed WriteAPIs management. Keeping single instance for each org and bucket pair.
+
 ## 1.4.0 [2020-07-17]
 ### Breaking changes
 1. [#156](https://github.com/influxdata/influxdb-client-go/pull/156) Fixing Go naming and code style violations: 

--- a/client.go
+++ b/client.go
@@ -199,7 +199,8 @@ func (c *clientImpl) WriteAPIBlocking(org, bucket string) api.WriteAPIBlocking {
 
 func (c *clientImpl) Close() {
 	for key, w := range c.writeAPIs {
-		w.Close()
+		wa := w.(*api.WriteAPIImpl)
+		wa.Close()
 		delete(c.writeAPIs, key)
 	}
 	for key := range c.syncWriteAPIs {

--- a/client.go
+++ b/client.go
@@ -63,18 +63,19 @@ type Client interface {
 
 // clientImpl implements Client interface
 type clientImpl struct {
-	serverURL   string
-	options     *Options
-	writeAPIs   []api.WriteAPI
-	lock        sync.Mutex
-	httpService ihttp.Service
-	apiClient   *domain.ClientWithResponses
-	authAPI     api.AuthorizationsAPI
-	orgAPI      api.OrganizationsAPI
-	usersAPI    api.UsersAPI
-	deleteAPI   api.DeleteAPI
-	bucketsAPI  api.BucketsAPI
-	labelsAPI   api.LabelsAPI
+	serverURL     string
+	options       *Options
+	writeAPIs     map[string]api.WriteAPI
+	syncWriteAPIs map[string]api.WriteAPIBlocking
+	lock          sync.Mutex
+	httpService   ihttp.Service
+	apiClient     *domain.ClientWithResponses
+	authAPI       api.AuthorizationsAPI
+	orgAPI        api.OrganizationsAPI
+	usersAPI      api.UsersAPI
+	deleteAPI     api.DeleteAPI
+	bucketsAPI    api.BucketsAPI
+	labelsAPI     api.LabelsAPI
 }
 
 // NewClient creates Client for connecting to given serverURL with provided authentication token, with the default options.
@@ -96,11 +97,12 @@ func NewClientWithOptions(serverURL string, authToken string, options *Options) 
 	}
 	service := ihttp.NewService(normServerURL, "Token "+authToken, options.httpOptions)
 	client := &clientImpl{
-		serverURL:   serverURL,
-		options:     options,
-		writeAPIs:   make([]api.WriteAPI, 0, 5),
-		httpService: service,
-		apiClient:   domain.NewClientWithResponses(service),
+		serverURL:     serverURL,
+		options:       options,
+		writeAPIs:     make(map[string]api.WriteAPI, 5),
+		syncWriteAPIs: make(map[string]api.WriteAPIBlocking, 5),
+		httpService:   service,
+		apiClient:     domain.NewClientWithResponses(service),
 	}
 	log.Log.SetDebugLevel(client.Options().LogLevel())
 	log.Log.Infof("Using URL '%s', token '%s'", serverURL, authToken)
@@ -174,19 +176,34 @@ func (c *clientImpl) Health(ctx context.Context) (*domain.HealthCheck, error) {
 }
 
 func (c *clientImpl) WriteAPI(org, bucket string) api.WriteAPI {
-	w := api.NewWriteAPI(org, bucket, c.httpService, c.options.writeOptions)
-	c.writeAPIs = append(c.writeAPIs, w)
-	return w
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	key := org + "_" + bucket
+	if _, ok := c.writeAPIs[key]; !ok {
+		w := api.NewWriteAPI(org, bucket, c.httpService, c.options.writeOptions)
+		c.writeAPIs[key] = w
+	}
+	return c.writeAPIs[key]
 }
 
 func (c *clientImpl) WriteAPIBlocking(org, bucket string) api.WriteAPIBlocking {
-	w := api.NewWriteAPIBlocking(org, bucket, c.httpService, c.options.writeOptions)
-	return w
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	key := org + "_" + bucket
+	if _, ok := c.syncWriteAPIs[key]; !ok {
+		w := api.NewWriteAPIBlocking(org, bucket, c.httpService, c.options.writeOptions)
+		c.syncWriteAPIs[key] = w
+	}
+	return c.syncWriteAPIs[key]
 }
 
 func (c *clientImpl) Close() {
-	for _, w := range c.writeAPIs {
+	for key, w := range c.writeAPIs {
 		w.Close()
+		delete(c.writeAPIs, key)
+	}
+	for key := range c.syncWriteAPIs {
+		delete(c.syncWriteAPIs, key)
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -167,10 +167,14 @@ func (c *clientImpl) Health(ctx context.Context) (*domain.HealthCheck, error) {
 	return response.JSON200, nil
 }
 
+func createKey(org, bucket string) string {
+	return org + "\t" + bucket
+}
+
 func (c *clientImpl) WriteAPI(org, bucket string) api.WriteAPI {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	key := org + "_" + bucket
+	key := createKey(org, bucket)
 	if _, ok := c.writeAPIs[key]; !ok {
 		w := api.NewWriteAPI(org, bucket, c.httpService, c.options.writeOptions)
 		c.writeAPIs[key] = w
@@ -181,7 +185,7 @@ func (c *clientImpl) WriteAPI(org, bucket string) api.WriteAPI {
 func (c *clientImpl) WriteAPIBlocking(org, bucket string) api.WriteAPIBlocking {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	key := org + "_" + bucket
+	key := createKey(org, bucket)
 	if _, ok := c.syncWriteAPIs[key]; !ok {
 		w := api.NewWriteAPIBlocking(org, bucket, c.httpService, c.options.writeOptions)
 		c.syncWriteAPIs[key] = w

--- a/client_test.go
+++ b/client_test.go
@@ -45,6 +45,37 @@ func TestUrls(t *testing.T) {
 	}
 }
 
+func TestWriteAPIManagement(t *testing.T) {
+	data := []struct {
+		org          string
+		bucket       string
+		expectedCout int
+	}{
+		{"o1", "b1", 1},
+		{"o1", "b2", 2},
+		{"o1", "b1", 2},
+		{"o2", "b1", 3},
+		{"o2", "b2", 4},
+		{"o1", "b2", 4},
+		{"o1", "b3", 5},
+		{"o2", "b2", 5},
+	}
+	c := NewClient("http://localhost", "x").(*clientImpl)
+	for i, d := range data {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			w := c.WriteAPI(d.org, d.bucket)
+			assert.NotNil(t, w)
+			assert.Len(t, c.writeAPIs, d.expectedCout)
+			wb := c.WriteAPIBlocking(d.org, d.bucket)
+			assert.NotNil(t, wb)
+			assert.Len(t, c.syncWriteAPIs, d.expectedCout)
+		})
+	}
+	c.Close()
+	assert.Len(t, c.writeAPIs, 0)
+	assert.Len(t, c.syncWriteAPIs, 0)
+}
+
 func TestUserAgent(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
Closes #163 

## Proposed Changes

Keeping a single instance of WriteAPI and WriteAPIBlocking for each org and bucket pair.

## Checklist

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

