### PR TITLE
fix: Closing body at the end of the result (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug fixes 
 1. [#175](https://github.com/influxdata/influxdb-client-go/pull/175) Fixed WriteAPIs management. Keeping single instance for each org and bucket pair.
+1. [#184](https://github.com/influxdata/influxdb-client-go/pull/184) Closing result at end of reading to avoid leaked connections.
 
 ## 1.4.0 [2020-07-17]
 ### Breaking changes

--- a/api/query.go
+++ b/api/query.go
@@ -220,6 +220,8 @@ const (
 // During the first time it is called, Next creates also table metadata
 // Actual parsed row is available through Record() function
 // Returns false in case of end or an error, otherwise true
+// Close() is called automatically at the end of the result or in case of an error.
+// If result is not read to the end, it must be closed explicitly.
 func (q *QueryTableResult) Next() bool {
 	var row []string
 	// set closing query in case of preliminary return
@@ -241,7 +243,7 @@ func (q *QueryTableResult) Next() bool {
 readRow:
 	row, q.err = q.csvReader.Read()
 	if q.err == io.EOF {
-		q.err = nil
+		q.err = q.Close()
 		return false
 	}
 	if q.err != nil {


### PR DESCRIPTION
Closes #183

Closing result (body) at the end of the result


## Checklist


- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

