### PR TITLE
docs: Adding clarification that server URL needs to be base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.0 [in progress]
+### Documentation
+1. [#189](https://github.com/influxdata/influxdb-client-go/pull/189) Added clarification that server URL has to be the InfluxDB server base URL to API docs and all examples.   
+
+
 ## 2.0.1 [2020-08-14]
 ### Bug fixes 
 1. [#187](https://github.com/influxdata/influxdb-client-go/pull/187) Properly updated library for new major version.

--- a/README.md
+++ b/README.md
@@ -71,18 +71,18 @@ import (
 )
 
 func main() {
-    // create new client with default option for server url authenticate by token
+    // Create a new client using an InfluxDB server base URL and an authentication token
     client := influxdb2.NewClient("http://localhost:9999", "my-token")
-    // user blocking write client for writes to desired bucket
+    // Use blocking write client for writes to desired bucket
     writeAPI := client.WriteAPIBlocking("my-org", "my-bucket")
-    // create point using full params constructor 
+    // Create point using full params constructor 
     p := influxdb2.NewPoint("stat",
         map[string]string{"unit": "temperature"},
         map[string]interface{}{"avg": 24.5, "max": 45},
         time.Now())
     // write point immediately 
     writeAPI.WritePoint(context.Background(), p)
-    // create point using fluent style
+    // Create point using fluent style
     p = influxdb2.NewPointWithMeasurement("stat").
         AddTag("unit", "temperature").
         AddField("avg", 23.2).
@@ -94,9 +94,9 @@ func main() {
     line := fmt.Sprintf("stat,unit=temperature avg=%f,max=%f", 23.5, 45.0)
     writeAPI.WriteRecord(context.Background(), line)
 
-    // get query client
+    // Get query client
     queryAPI := client.QueryAPI("my-org")
-    // get parser flux query result
+    // Get parser flux query result
     result, err := queryAPI.Query(context.Background(), `from(bucket:"my-bucket")|> range(start: -1h) |> filter(fn: (r) => r._measurement == "stat")`)
     if err == nil {
         // Use Next() to iterate over query result lines
@@ -140,7 +140,7 @@ Client offers two ways of writing, non-blocking and blocking.
 
 ### Non-blocking write client 
 Non-blocking write client uses implicit batching. Data are asynchronously
-written to the underlying buffer and they are automatically sent to a server when the size of the write buffer reaches the batch size, default 1000, or the flush interval, default 1s, times out.
+written to the underlying buffer and they are automatically sent to a server when the size of the write buffer reaches the batch size, default 5000, or the flush interval, default 1s, times out.
 Writes are automatically retried on server back pressure.
 
 This write client also offers synchronous blocking method to ensure that write buffer is flushed and all pending writes are finished, 
@@ -161,7 +161,8 @@ import (
 )
 
 func main() {
-    // Create client and set batch size to 20 
+    // Create a new client using an InfluxDB server base URL and an authentication token
+    // and set batch size to 20 
     client := influxdb2.NewClientWithOptions("http://localhost:9999", "my-token",
         influxdb2.DefaultOptions().SetBatchSize(20))
     // Get non-blocking write client
@@ -210,7 +211,7 @@ import (
 )
 
 func main() {
-    // Create client
+    // Create a new client using an InfluxDB server base URL and an authentication token
     client := influxdb2.NewClient("http://localhost:9999", "my-token")
     // Get non-blocking write client
     writeAPI := client.WriteAPI("my-org", "my-bucket")
@@ -261,7 +262,7 @@ import (
 )
 
 func main() {
-    // Create client
+    // Create a new client using an InfluxDB server base URL and an authentication token
     client := influxdb2.NewClient("http://localhost:9999", "my-token")
     // Get blocking write client
     writeAPI := client.WriteAPIBlocking("my-org","my-bucket")
@@ -312,7 +313,7 @@ import (
 )
 
 func main() {
-    // Create client
+    // Create a new client using an InfluxDB server base URL and an authentication token
     client := influxdb2.NewClient("http://localhost:9999", "my-token")
     // Get query client
     queryAPI := client.QueryAPI("my-org")
@@ -355,7 +356,7 @@ import (
 )
 
 func main() {
-    // Create client
+    // Create a new client using an InfluxDB server base URL and an authentication token
     client := influxdb2.NewClient("http://localhost:9999", "my-token")
     // Get query client
     queryAPI := client.QueryAPI("my-org")
@@ -407,8 +408,8 @@ import (
 func main() {
     userName := "my-user"
     password := "my-password"
-    // Create a client
-    // Supply a string in the form: "username:password" as a token. Set empty value for an unauthenticated server
+     // Create a new client using an InfluxDB server base URL and an authentication token
+    // For authentication token supply a string in the form: "username:password" as a token. Set empty value for an unauthenticated server
     client := influxdb2.NewClient("http://localhost:8086", fmt.Sprintf("%s:%s",userName, password))
     // Get the blocking write client
     // Supply a string in the form database/retention-policy as a bucket. Skip retention policy for the default one, use just a database name (without the slash character)

--- a/api/examples_test.go
+++ b/api/examples_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func ExampleBucketsAPI() {
-	// Create influxdb client
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")
 
 	ctx := context.Background()
@@ -44,7 +44,7 @@ func ExampleBucketsAPI() {
 }
 
 func ExampleWriteAPIBlocking() {
-	// Create client
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")
 	// Get blocking write client
 	writeAPI := client.WriteAPIBlocking("my-org", "my-bucket")
@@ -77,7 +77,7 @@ func ExampleWriteAPIBlocking() {
 }
 
 func ExampleWriteAPI() {
-	// Create client
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")
 	// Get non-blocking write client
 	writeAPI := client.WriteAPI("my-org", "my-bucket")
@@ -109,7 +109,7 @@ func ExampleWriteAPI() {
 }
 
 func ExampleWriteAPI_errors() {
-	// Create client
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")
 	// Get non-blocking write client
 	writeAPI := client.WriteAPI("my-org", "my-bucket")
@@ -144,7 +144,7 @@ func ExampleWriteAPI_errors() {
 }
 
 func ExampleQueryAPI_query() {
-	// Create client
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")
 	// Get query client
 	queryAPI := client.QueryAPI("my-org")
@@ -172,7 +172,7 @@ func ExampleQueryAPI_query() {
 }
 
 func ExampleQueryAPI_queryRaw() {
-	// Create client
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")
 	// Get query client
 	queryAPI := client.QueryAPI("my-org")
@@ -190,7 +190,7 @@ func ExampleQueryAPI_queryRaw() {
 }
 
 func ExampleOrganizationsAPI() {
-	// Create influxdb client
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")
 
 	// Get Organizations API client
@@ -238,7 +238,7 @@ func ExampleOrganizationsAPI() {
 }
 
 func ExampleAuthorizationsAPI() {
-	// Create influxdb client
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")
 
 	// Find user to grant permission
@@ -292,7 +292,7 @@ func ExampleAuthorizationsAPI() {
 }
 
 func ExampleUsersAPI() {
-	// Create influxdb client
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")
 
 	// Find organization
@@ -326,7 +326,7 @@ func ExampleUsersAPI() {
 }
 
 func ExampleLabelsAPI() {
-	// Create influxdb client
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")
 
 	ctx := context.Background()
@@ -360,7 +360,7 @@ func ExampleLabelsAPI() {
 }
 
 func ExampleDeleteAPI() {
-	// Create influxdb client
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")
 
 	ctx := context.Background()

--- a/client.go
+++ b/client.go
@@ -79,16 +79,18 @@ type clientImpl struct {
 }
 
 // NewClient creates Client for connecting to given serverURL with provided authentication token, with the default options.
-// Authentication token can be empty in case of connecting to newly installed InfluxDB server, which has not been set up yet.
-// In such case Setup will set authentication token
+// serverURL is the InfluxDB server base URL, e.g. http://localhost:9999,
+// authToken is an authentication token. It can be empty in case of connecting to newly installed InfluxDB server, which has not been set up yet.
+// In such case, calling Setup() will set the authentication token.
 func NewClient(serverURL string, authToken string) Client {
 	return NewClientWithOptions(serverURL, authToken, DefaultOptions())
 }
 
 // NewClientWithOptions creates Client for connecting to given serverURL with provided authentication token
-// and configured with custom Options
-// Authentication token can be empty in case of connecting to newly installed InfluxDB server, which has not been set up yet.
-// In such case Setup will set authentication token
+// and configured with custom Options.
+// serverURL is the InfluxDB server base URL, e.g. http://localhost:9999,
+// authToken is an authentication token. It can be empty in case of connecting to newly installed InfluxDB server, which has not been set up yet.
+// In such case, calling Setup() will set authentication token
 func NewClientWithOptions(serverURL string, authToken string, options *Options) Client {
 	normServerURL := serverURL
 	if !strings.HasSuffix(normServerURL, "/") {

--- a/examples_test.go
+++ b/examples_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ExampleClient_newClient() {
-	// Create client
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")
 
 	// always close client at the end
@@ -17,6 +17,7 @@ func ExampleClient_newClient() {
 }
 
 func ExampleClient_newClientWithOptions() {
+	// Create a new client using an InfluxDB server base URL and an authentication token
 	// Create client and set batch size to 20
 	client := influxdb2.NewClientWithOptions("http://localhost:9999", "my-token",
 		influxdb2.DefaultOptions().SetBatchSize(20))


### PR DESCRIPTION
Closes #182

## Proposed Changes

Adding clarification that server URL needs to be base URL to client API docs and all examples in Readme and API docs

## Checklist


- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

