### PR TITLE
fix: boolDatatype not match line protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.0 [in progress]
 ### Bug fixes
-1. [#190](https://github.com/influxdata/influxdb-client-go/issues/190) Fixed QueryTableResult.Next() failed to parse boolean datatype.
+1. [#191](https://github.com/influxdata/influxdb-client-go/pull/191) Fixed QueryTableResult.Next() failed to parse boolean datatype.
 
 ### Documentation
 1. [#189](https://github.com/influxdata/influxdb-client-go/pull/189) Added clarification that server URL has to be the InfluxDB server base URL to API docs and all examples.   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 2.1.0 [in progress]
+### Bug fixes
+1. [#190](https://github.com/influxdata/influxdb-client-go/issues/190) Fixed QueryTableResult.Next() failed to parse boolean datatype.
+
 ### Documentation
 1. [#189](https://github.com/influxdata/influxdb-client-go/pull/189) Added clarification that server URL has to be the InfluxDB server base URL to API docs and all examples.   
 

--- a/api/query.go
+++ b/api/query.go
@@ -32,7 +32,7 @@ import (
 const (
 	stringDatatype       = "string"
 	doubleDatatype       = "double"
-	boolDatatype         = "bool"
+	boolDatatype         = "boolean"
 	longDatatype         = "long"
 	uLongDatatype        = "unsignedLong"
 	durationDatatype     = "duration"

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -120,7 +120,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 ,,1,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T10:34:08.135814545Z,4,i,test,1,adsfasdf
 ,,1,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T22:08:44.850214724Z,-1,i,test,1,adsfasdf
 
-#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,bool,string,string,string,string
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,boolean,string,string,string,string
 #group,false,false,true,true,false,false,true,true,true,true
 #default,_result,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,a,b
@@ -228,7 +228,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 			query.NewFluxColumnFull("dateTime:RFC3339", "", "_start", true, 2),
 			query.NewFluxColumnFull("dateTime:RFC3339", "", "_stop", true, 3),
 			query.NewFluxColumnFull("dateTime:RFC3339", "", "_time", false, 4),
-			query.NewFluxColumnFull("bool", "", "_value", false, 5),
+			query.NewFluxColumnFull("boolean", "", "_value", false, 5),
 			query.NewFluxColumnFull("string", "", "_field", true, 6),
 			query.NewFluxColumnFull("string", "", "_measurement", true, 7),
 			query.NewFluxColumnFull("string", "", "a", true, 8),


### PR DESCRIPTION
## Proposed Changes

fix [bug](https://github.com/influxdata/influxdb-client-go/issues/190): failed to parse boolean datatype in `QueryTableResult`.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
