### PR TITLE
fix: Client.Close() also closes idle connections 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 1. [#189](https://github.com/influxdata/influxdb-client-go/pull/189) Added clarification that server URL has to be the InfluxDB server base URL to API docs and all examples.   
 
 ### Bug fixes 
-1. [#192](https://github.com/influxdata/influxdb-client-go/pull/192) Client.Close() closes also idle connections, if HTTP client was crated internally 
+1. [#192](https://github.com/influxdata/influxdb-client-go/pull/192) Client.Close() closes idle connections of internally created HTTP client 
 
 ## 2.0.1 [2020-08-14]
 ### Bug fixes 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ### Documentation
 1. [#189](https://github.com/influxdata/influxdb-client-go/pull/189) Added clarification that server URL has to be the InfluxDB server base URL to API docs and all examples.   
 
+### Bug fixes 
+1. [#192](https://github.com/influxdata/influxdb-client-go/pull/192) Client.Close() closes also idle connections, if HTTP client was crated internally 
 
 ## 2.0.1 [2020-08-14]
 ### Bug fixes 

--- a/api/http/options.go
+++ b/api/http/options.go
@@ -15,6 +15,8 @@ import (
 type Options struct {
 	// HTTP client. Default is http.DefaultClient.
 	httpClient *http.Client
+	// Flag whether http client was created internally
+	ownClient bool
 	// TLS configuration for secure connection. Default nil
 	tlsConfig *tls.Config
 	// HTTP request timeout in sec. Default 20
@@ -37,6 +39,7 @@ func (o *Options) HTTPClient() *http.Client {
 				TLSClientConfig:     o.TLSConfig(),
 			},
 		}
+		o.ownClient = true
 	}
 	return o.httpClient
 }
@@ -49,7 +52,13 @@ func (o *Options) HTTPClient() *http.Client {
 // to be ignored.
 func (o *Options) SetHTTPClient(c *http.Client) *Options {
 	o.httpClient = c
+	o.ownClient = false
 	return o
+}
+
+// OwnHTTPClient returns true of HTTP client was created internally. False if it was set externally.
+func (o *Options) OwnHTTPClient() bool {
+	return o.ownClient
 }
 
 // TLSConfig returns tls.Config

--- a/api/http/options_test.go
+++ b/api/http/options_test.go
@@ -18,6 +18,8 @@ func TestDefaultOptions(t *testing.T) {
 	opts := http.DefaultOptions()
 	assert.Equal(t, (*tls.Config)(nil), opts.TLSConfig())
 	assert.Equal(t, uint(20), opts.HTTPRequestTimeout())
+	assert.NotNil(t, opts.HTTPClient())
+	assert.True(t, opts.OwnHTTPClient())
 }
 
 func TestOptionsSetting(t *testing.T) {
@@ -32,6 +34,7 @@ func TestOptionsSetting(t *testing.T) {
 	if client := opts.HTTPClient(); assert.NotNil(t, client) {
 		assert.Equal(t, 50*time.Second, client.Timeout)
 		assert.Equal(t, tlsConfig, client.Transport.(*nethttp.Transport).TLSClientConfig)
+		assert.True(t, opts.OwnHTTPClient())
 	}
 
 	client := &nethttp.Client{
@@ -40,4 +43,5 @@ func TestOptionsSetting(t *testing.T) {
 	opts = http.DefaultOptions()
 	opts.SetHTTPClient(client)
 	assert.Equal(t, client, opts.HTTPClient())
+	assert.False(t, opts.OwnHTTPClient())
 }


### PR DESCRIPTION
Closes #183 

## Proposed Changes
Client.Close() also closes idle connections if the HTTP client was created internally  (#183)

## Checklist

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

