### PR TITLE
feat: Added SignIn and SignOut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 2.1.0 [in progress]
+### Features
+1. [#193](https://github.com/influxdata/influxdb-client-go/pull/193) Added authentication using username and password. See `UsersAPI.SignIn()` and `UsersAPI.SignOut()`
+
 ### Bug fixes
 1. [#191](https://github.com/influxdata/influxdb-client-go/pull/191) Fixed QueryTableResult.Next() failed to parse boolean datatype.
 1. [#192](https://github.com/influxdata/influxdb-client-go/pull/192) Client.Close() closes idle connections of internally created HTTP client

--- a/api/examples_test.go
+++ b/api/examples_test.go
@@ -325,6 +325,33 @@ func ExampleUsersAPI() {
 	client.Close()
 }
 
+func ExampleUsersAPI_signInOut() {
+	// Create a new client using an InfluxDB server base URL and empty token
+	client := influxdb2.NewClient("http://localhost:9999", "")
+	// Always close client at the end
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// The first call must be signIn
+	err := client.UsersAPI().SignIn(ctx, "username", "password")
+	if err != nil {
+		panic(err)
+	}
+
+	// Perform some authorized operations
+	err = client.WriteAPIBlocking("my-org", "my-bucket").WriteRecord(ctx, "test,a=rock,b=local f=1.2,i=-5i")
+	if err != nil {
+		panic(err)
+	}
+
+	// Sign out at the end
+	err = client.UsersAPI().SignOut(ctx)
+	if err != nil {
+		panic(err)
+	}
+}
+
 func ExampleLabelsAPI() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient("http://localhost:9999", "my-token")

--- a/api/http/options.go
+++ b/api/http/options.go
@@ -50,6 +50,7 @@ func (o *Options) HTTPClient() *http.Client {
 //
 // Setting the HTTPClient will cause the other HTTP options
 // to be ignored.
+// In case of UsersAPI.SignIn() is used, HTTPClient.Jar will be used for storing session cookie.
 func (o *Options) SetHTTPClient(c *http.Client) *Options {
 	o.httpClient = c
 	o.ownClient = false

--- a/api/http/service.go
+++ b/api/http/service.go
@@ -124,7 +124,9 @@ func (s *service) DoHTTPRequest(req *http.Request, requestCallback RequestCallba
 
 func (s *service) DoHTTPRequestWithResponse(req *http.Request, requestCallback RequestCallback) (*http.Response, error) {
 	log.Infof("HTTP %s req to %s", req.Method, req.URL.String())
-	req.Header.Set("Authorization", s.authorization)
+	if len(s.authorization) > 0 {
+		req.Header.Set("Authorization", s.authorization)
+	}
 	req.Header.Set("User-Agent", http2.UserAgent)
 	if requestCallback != nil {
 		requestCallback(req)

--- a/api/users.go
+++ b/api/users.go
@@ -43,7 +43,7 @@ type UsersAPI interface {
 	Me(ctx context.Context) (*domain.User, error)
 	// MeUpdatePassword set password of actual user
 	MeUpdatePassword(ctx context.Context, oldPassword, newPassword string) error
-	// SignIn signs in a user with username and password credentials. This overrides any previously set authentication token
+	// SignIn exchanges username and password credentials to establish an authenticated session with the InfluxDB server. The Client's authentication token is then ignored, it can be empty.
 	SignIn(ctx context.Context, username, password string) error
 	// SignOut signs out previously signed in user
 	SignOut(ctx context.Context) error

--- a/client.go
+++ b/client.go
@@ -98,7 +98,11 @@ func NewClientWithOptions(serverURL string, authToken string, options *Options) 
 		// For subsequent path parts concatenation, url has to end with '/'
 		normServerURL = serverURL + "/"
 	}
-	service := http.NewService(normServerURL, "Token "+authToken, options.httpOptions)
+	authorization := ""
+	if len(authToken) > 0 {
+		authorization = "Token " + authToken
+	}
+	service := http.NewService(normServerURL, authorization, options.httpOptions)
 	client := &clientImpl{
 		serverURL:     serverURL,
 		options:       options,
@@ -245,7 +249,7 @@ func (c *clientImpl) UsersAPI() api.UsersAPI {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if c.usersAPI == nil {
-		c.usersAPI = api.NewUsersAPI(c.apiClient)
+		c.usersAPI = api.NewUsersAPI(c.apiClient, c.httpService, c.options.HTTPClient())
 	}
 	return c.usersAPI
 }

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0 // test dependency
+	golang.org/x/net v0.0.0-20191112182307-2180aed22343
 	gopkg.in/yaml.v2 v2.2.5
 )

--- a/options.go
+++ b/options.go
@@ -144,6 +144,7 @@ func (o *Options) HTTPClient() *nethttp.Client {
 //
 // Setting the HTTPClient will cause the other HTTP options
 // to be ignored.
+// In case of UsersAPI.SignIn() is used, HTTPClient.Jar will be used for storing session cookie.
 func (o *Options) SetHTTPClient(c *nethttp.Client) *Options {
 	o.httpOptions.SetHTTPClient(c)
 	return o


### PR DESCRIPTION
Closes #45

## Proposed Changes
Allowing a user to authenticate via username and password. Available via explicit calls to UsersAPI.SignIn() and UsersAPI.SignOut()

## Checklist

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

