### PR TITLE
feat: Changing server port 9999 -> 8086

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ jobs:
     environment:
       ENV: CI
       GO111MODULE: "on"
-      INFLUXDB2_URL: "http://localhost:9999"
-      INFLUXDB_URL: "http://localhost:8086"
-      INFLUXDB2_ONBOARDING_URL: "http://localhost:9990"
+      INFLUXDB2_URL: "http://localhost:8086"
+      INFLUXDB_URL: "http://localhost:8087"
+      INFLUXDB2_ONBOARDING_URL: "http://localhost:8089"
     steps:
       - checkout
 #      - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Documentation
 1. [#189](https://github.com/influxdata/influxdb-client-go/pull/189) Added clarification that server URL has to be the InfluxDB server base URL to API docs and all examples.   
+1. [#196](https://github.com/influxdata/influxdb-client-go/pull/196) Changed default server port 9999 to 8086 in docs and examples  
 
 ## 2.0.1 [2020-08-14]
 ### Bug fixes 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ import (
 
 func main() {
     // Create a new client using an InfluxDB server base URL and an authentication token
-    client := influxdb2.NewClient("http://localhost:9999", "my-token")
+    client := influxdb2.NewClient("http://localhost:8086", "my-token")
     // Use blocking write client for writes to desired bucket
     writeAPI := client.WriteAPIBlocking("my-org", "my-bucket")
     // Create point using full params constructor 
@@ -120,14 +120,14 @@ func main() {
 The InfluxDBClient uses set of options to configure behavior. These are available in the [Options](https://github.com/influxdata/influxdb-client-go/blob/master/options.go) object
 Creating a client instance using
 ```go
-client := influxdb2.NewClient("http://localhost:9999", "my-token")
+client := influxdb2.NewClient("http://localhost:8086", "my-token")
 ```
 will use the default options.
 
 To set different configuration values, e.g. to set gzip compression and trust all server certificates, get default options 
 and change what is needed: 
 ```go
-client := influxdb2.NewClientWithOptions("http://localhost:9999", "my-token", 
+client := influxdb2.NewClientWithOptions("http://localhost:8086", "my-token", 
     influxdb2.DefaultOptions().
         SetUseGZip(true).
         SetTLSConfig(&tls.Config{
@@ -163,7 +163,7 @@ import (
 func main() {
     // Create a new client using an InfluxDB server base URL and an authentication token
     // and set batch size to 20 
-    client := influxdb2.NewClientWithOptions("http://localhost:9999", "my-token",
+    client := influxdb2.NewClientWithOptions("http://localhost:8086", "my-token",
         influxdb2.DefaultOptions().SetBatchSize(20))
     // Get non-blocking write client
     writeAPI := client.WriteAPI("my-org","my-bucket")
@@ -212,7 +212,7 @@ import (
 
 func main() {
     // Create a new client using an InfluxDB server base URL and an authentication token
-    client := influxdb2.NewClient("http://localhost:9999", "my-token")
+    client := influxdb2.NewClient("http://localhost:8086", "my-token")
     // Get non-blocking write client
     writeAPI := client.WriteAPI("my-org", "my-bucket")
     // Get errors channel
@@ -263,7 +263,7 @@ import (
 
 func main() {
     // Create a new client using an InfluxDB server base URL and an authentication token
-    client := influxdb2.NewClient("http://localhost:9999", "my-token")
+    client := influxdb2.NewClient("http://localhost:8086", "my-token")
     // Get blocking write client
     writeAPI := client.WriteAPIBlocking("my-org","my-bucket")
     // write some points
@@ -314,7 +314,7 @@ import (
 
 func main() {
     // Create a new client using an InfluxDB server base URL and an authentication token
-    client := influxdb2.NewClient("http://localhost:9999", "my-token")
+    client := influxdb2.NewClient("http://localhost:8086", "my-token")
     // Get query client
     queryAPI := client.QueryAPI("my-org")
     // get QueryTableResult
@@ -357,7 +357,7 @@ import (
 
 func main() {
     // Create a new client using an InfluxDB server base URL and an authentication token
-    client := influxdb2.NewClient("http://localhost:9999", "my-token")
+    client := influxdb2.NewClient("http://localhost:8086", "my-token")
     // Get query client
     queryAPI := client.QueryAPI("my-org")
     // Query and get complete result as a string

--- a/api/authorizations_e2e_test.go
+++ b/api/authorizations_e2e_test.go
@@ -30,7 +30,7 @@ func getEnvValue(key, defVal string) string {
 
 func init() {
 	authToken = getEnvValue("INFLUXDB2_TOKEN", "my-token")
-	serverURL = getEnvValue("INFLUXDB2_URL", "http://localhost:9999")
+	serverURL = getEnvValue("INFLUXDB2_URL", "http://localhost:8086")
 }
 
 func TestAuthorizationsAPI(t *testing.T) {

--- a/api/buckets_e2e_test.go
+++ b/api/buckets_e2e_test.go
@@ -198,7 +198,7 @@ func TestBucketsAPI_paging(t *testing.T) {
 	// collect all buckets including system ones created for new organization
 	buckets, err := bucketsAPI.GetBuckets(ctx)
 	require.Nil(t, err, err)
-	//store #all buckets before creating new ones
+	//store #all buckets before creating new ones (typically 5 - 2xsytem buckets (_tasks, _monitoring) + initial bucket "my-bucket")
 	bucketsNum := len(*buckets)
 
 	// create new buckets inside org
@@ -219,7 +219,8 @@ func TestBucketsAPI_paging(t *testing.T) {
 	buckets, err = bucketsAPI.GetBuckets(ctx, api.PagingWithOffset(20))
 	require.Nil(t, err, err)
 	require.NotNil(t, buckets)
-	assert.Len(t, *buckets, 10+bucketsNum)
+	// should return 15, but sometimes repeats system buckets also in 2nd page
+	assert.True(t, len(*buckets) >= 10+bucketsNum, "Invalid len: %d >= %d", len(*buckets), 10+bucketsNum)
 	// test paging with increase limit to cover all buckets
 	buckets, err = bucketsAPI.GetBuckets(ctx, api.PagingWithLimit(100))
 	require.Nil(t, err, err)

--- a/api/examples_test.go
+++ b/api/examples_test.go
@@ -14,7 +14,7 @@ import (
 
 func ExampleBucketsAPI() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 
 	ctx := context.Background()
 	// Get Buckets API client
@@ -45,7 +45,7 @@ func ExampleBucketsAPI() {
 
 func ExampleWriteAPIBlocking() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 	// Get blocking write client
 	writeAPI := client.WriteAPIBlocking("my-org", "my-bucket")
 	// write some points
@@ -78,7 +78,7 @@ func ExampleWriteAPIBlocking() {
 
 func ExampleWriteAPI() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 	// Get non-blocking write client
 	writeAPI := client.WriteAPI("my-org", "my-bucket")
 	// write some points
@@ -110,7 +110,7 @@ func ExampleWriteAPI() {
 
 func ExampleWriteAPI_errors() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 	// Get non-blocking write client
 	writeAPI := client.WriteAPI("my-org", "my-bucket")
 	// Get errors channel
@@ -145,7 +145,7 @@ func ExampleWriteAPI_errors() {
 
 func ExampleQueryAPI_query() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 	// Get query client
 	queryAPI := client.QueryAPI("my-org")
 	// get QueryTableResult
@@ -173,7 +173,7 @@ func ExampleQueryAPI_query() {
 
 func ExampleQueryAPI_queryRaw() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 	// Get query client
 	queryAPI := client.QueryAPI("my-org")
 	// Query and get complete result as a string
@@ -191,7 +191,7 @@ func ExampleQueryAPI_queryRaw() {
 
 func ExampleOrganizationsAPI() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 
 	// Get Organizations API client
 	orgAPI := client.OrganizationsAPI()
@@ -239,7 +239,7 @@ func ExampleOrganizationsAPI() {
 
 func ExampleAuthorizationsAPI() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 
 	// Find user to grant permission
 	user, err := client.UsersAPI().FindUserByName(context.Background(), "user-01")
@@ -293,7 +293,7 @@ func ExampleAuthorizationsAPI() {
 
 func ExampleUsersAPI() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 
 	// Find organization
 	org, err := client.OrganizationsAPI().FindOrganizationByName(context.Background(), "my-org")
@@ -327,7 +327,7 @@ func ExampleUsersAPI() {
 
 func ExampleUsersAPI_signInOut() {
 	// Create a new client using an InfluxDB server base URL and empty token
-	client := influxdb2.NewClient("http://localhost:9999", "")
+	client := influxdb2.NewClient("http://localhost:8086", "")
 	// Always close client at the end
 	defer client.Close()
 
@@ -354,7 +354,7 @@ func ExampleUsersAPI_signInOut() {
 
 func ExampleLabelsAPI() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 
 	ctx := context.Background()
 	// Get Labels API client
@@ -388,7 +388,7 @@ func ExampleLabelsAPI() {
 
 func ExampleDeleteAPI() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 
 	ctx := context.Background()
 	// Get Delete API client

--- a/api/http/service.go
+++ b/api/http/service.go
@@ -9,7 +9,7 @@
 //
 // Service can be obtained from client using HTTPService() method.
 // It can be also created directly. To instantiate a Service use NewService(). Remember, the authorization param is in form "Token your-auth-token". e.g. "Token DXnd7annkGteV5Wqx9G3YjO9Ezkw87nHk8OabcyHCxF5451kdBV0Ag2cG7OmZZgCUTHroagUPdxbuoyen6TSPw==".
-//     srv := http.NewService("http://localhost:9999", "Token my-token", http.DefaultOptions())
+//     srv := http.NewService("http://localhost:8086", "Token my-token", http.DefaultOptions())
 package http
 
 import (

--- a/api/http/service_test.go
+++ b/api/http/service_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestService(t *testing.T) {
-	srv := NewService("http://localhost:9999/aa/", "Token my-token", DefaultOptions())
-	assert.Equal(t, "http://localhost:9999/aa/", srv.ServerURL())
-	assert.Equal(t, "http://localhost:9999/aa/api/v2/", srv.ServerAPIURL())
+	srv := NewService("http://localhost:8086/aa/", "Token my-token", DefaultOptions())
+	assert.Equal(t, "http://localhost:8086/aa/", srv.ServerURL())
+	assert.Equal(t, "http://localhost:8086/aa/api/v2/", srv.ServerAPIURL())
 	assert.Equal(t, "Token my-token", srv.Authorization())
 }

--- a/api/users_e2e_test.go
+++ b/api/users_e2e_test.go
@@ -151,7 +151,7 @@ func TestUsersAPI_requestFailing(t *testing.T) {
 
 func TestSignInOut(t *testing.T) {
 	ctx := context.Background()
-	client := influxdb2.NewClient("http://localhost:9999", "")
+	client := influxdb2.NewClient("http://localhost:8086", "")
 
 	usersAPI := client.UsersAPI()
 
@@ -198,7 +198,7 @@ func TestSignInOut(t *testing.T) {
 	require.NotNil(t, user)
 
 	// 2nd client to use for new user auth
-	client2 := influxdb2.NewClient("http://localhost:9999", "")
+	client2 := influxdb2.NewClient("http://localhost:8086", "")
 
 	err = usersAPI.UpdateUserPassword(ctx, user, "123password")
 	assert.Nil(t, err)

--- a/client.go
+++ b/client.go
@@ -80,7 +80,7 @@ type clientImpl struct {
 }
 
 // NewClient creates Client for connecting to given serverURL with provided authentication token, with the default options.
-// serverURL is the InfluxDB server base URL, e.g. http://localhost:9999,
+// serverURL is the InfluxDB server base URL, e.g. http://localhost:8086,
 // authToken is an authentication token. It can be empty in case of connecting to newly installed InfluxDB server, which has not been set up yet.
 // In such case, calling Setup() will set the authentication token.
 func NewClient(serverURL string, authToken string) Client {
@@ -89,7 +89,7 @@ func NewClient(serverURL string, authToken string) Client {
 
 // NewClientWithOptions creates Client for connecting to given serverURL with provided authentication token
 // and configured with custom Options.
-// serverURL is the InfluxDB server base URL, e.g. http://localhost:9999,
+// serverURL is the InfluxDB server base URL, e.g. http://localhost:8086,
 // authToken is an authentication token. It can be empty in case of connecting to newly installed InfluxDB server, which has not been set up yet.
 // In such case, calling Setup() will set authentication token
 func NewClientWithOptions(serverURL string, authToken string, options *Options) Client {

--- a/client_e2e_test.go
+++ b/client_e2e_test.go
@@ -36,9 +36,9 @@ func getEnvValue(key, defVal string) string {
 
 func init() {
 	authToken = getEnvValue("INFLUXDB2_TOKEN", "my-token")
-	serverURL = getEnvValue("INFLUXDB2_URL", "http://localhost:9999")
-	serverV1URL = getEnvValue("INFLUXDB_URL", "http://localhost:8086")
-	onboardingURL = getEnvValue("INFLUXDB2_ONBOARDING_URL", "http://localhost:9990")
+	serverURL = getEnvValue("INFLUXDB2_URL", "http://localhost:8086")
+	serverV1URL = getEnvValue("INFLUXDB_URL", "http://localhost:8087")
+	onboardingURL = getEnvValue("INFLUXDB2_ONBOARDING_URL", "http://localhost:8089")
 }
 
 func TestSetup(t *testing.T) {
@@ -248,7 +248,7 @@ func TestQueryV1Compatibility(t *testing.T) {
 }
 
 func TestHTTPService(t *testing.T) {
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 	apiClient := domain.NewClientWithResponses(client.HTTPService())
 	org, err := client.OrganizationsAPI().FindOrganizationByName(context.Background(), "my-org")
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -25,12 +25,12 @@ func TestUrls(t *testing.T) {
 		serverAPIURL   string
 		writeURLPrefix string
 	}{
-		{"http://host:9999", "http://host:9999/api/v2/", "http://host:9999/api/v2/write"},
-		{"http://host:9999/", "http://host:9999/api/v2/", "http://host:9999/api/v2/write"},
-		{"http://host:9999/path", "http://host:9999/path/api/v2/", "http://host:9999/path/api/v2/write"},
-		{"http://host:9999/path/", "http://host:9999/path/api/v2/", "http://host:9999/path/api/v2/write"},
-		{"http://host:9999/path1/path2/path3", "http://host:9999/path1/path2/path3/api/v2/", "http://host:9999/path1/path2/path3/api/v2/write"},
-		{"http://host:9999/path1/path2/path3/", "http://host:9999/path1/path2/path3/api/v2/", "http://host:9999/path1/path2/path3/api/v2/write"},
+		{"http://host:8086", "http://host:8086/api/v2/", "http://host:8086/api/v2/write"},
+		{"http://host:8086/", "http://host:8086/api/v2/", "http://host:8086/api/v2/write"},
+		{"http://host:8086/path", "http://host:8086/path/api/v2/", "http://host:8086/path/api/v2/write"},
+		{"http://host:8086/path/", "http://host:8086/path/api/v2/", "http://host:8086/path/api/v2/write"},
+		{"http://host:8086/path1/path2/path3", "http://host:8086/path1/path2/path3/api/v2/", "http://host:8086/path1/path2/path3/api/v2/write"},
+		{"http://host:8086/path1/path2/path3/", "http://host:8086/path1/path2/path3/api/v2/", "http://host:8086/path1/path2/path3/api/v2/write"},
 	}
 	for _, url := range urls {
 		t.Run(url.serverURL, func(t *testing.T) {

--- a/examples_test.go
+++ b/examples_test.go
@@ -10,7 +10,7 @@ import (
 
 func ExampleClient_newClient() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 
 	// Always close client at the end
 	defer client.Close()
@@ -19,7 +19,7 @@ func ExampleClient_newClient() {
 func ExampleClient_newClientWithOptions() {
 	// Create a new client using an InfluxDB server base URL and an authentication token
 	// Create client and set batch size to 20
-	client := influxdb2.NewClientWithOptions("http://localhost:9999", "my-token",
+	client := influxdb2.NewClientWithOptions("http://localhost:8086", "my-token",
 		influxdb2.DefaultOptions().SetBatchSize(20))
 
 	// Always close client at the end
@@ -28,7 +28,7 @@ func ExampleClient_newClientWithOptions() {
 
 func ExampleClient_customServerAPICall() {
 	// Create a new client using an InfluxDB server base URL and empty token
-	client := influxdb2.NewClient("http://localhost:9999", "my-token")
+	client := influxdb2.NewClient("http://localhost:8086", "my-token")
 	// Always close client at the end
 	defer client.Close()
 	// Get generated client for server API calls

--- a/internal/write/service_test.go
+++ b/internal/write/service_test.go
@@ -59,7 +59,7 @@ func TestAddDefaultTags(t *testing.T) {
 
 func TestDefaultRetryDelay(t *testing.T) {
 	log.Log.SetLogLevel(log.DebugLevel)
-	hs := test.NewTestService(t, "http://localhost:9999")
+	hs := test.NewTestService(t, "http://localhost:8086")
 	opts := write.DefaultOptions()
 	ctx := context.Background()
 	srv := NewService("my-org", "my-bucket", hs, opts)
@@ -89,7 +89,7 @@ func TestDefaultRetryDelay(t *testing.T) {
 
 func TestCustomRetryDelayWithFLush(t *testing.T) {
 	log.Log.SetLogLevel(log.DebugLevel)
-	hs := test.NewTestService(t, "http://localhost:9999")
+	hs := test.NewTestService(t, "http://localhost:8086")
 	opts := write.DefaultOptions().SetRetryInterval(1)
 	ctx := context.Background()
 	srv := NewService("my-org", "my-bucket", hs, opts)
@@ -131,7 +131,7 @@ func TestCustomRetryDelayWithFLush(t *testing.T) {
 
 func TestBufferOverwrite(t *testing.T) {
 	log.Log.SetLogLevel(log.DebugLevel)
-	hs := test.NewTestService(t, "http://localhost:9999")
+	hs := test.NewTestService(t, "http://localhost:8086")
 	//
 	opts := write.DefaultOptions().SetRetryInterval(1).SetRetryBufferLimit(15000)
 	ctx := context.Background()
@@ -182,7 +182,7 @@ func TestBufferOverwrite(t *testing.T) {
 
 func TestMaxRetryInterval(t *testing.T) {
 	log.Log.SetLogLevel(log.DebugLevel)
-	hs := test.NewTestService(t, "http://localhost:9999")
+	hs := test.NewTestService(t, "http://localhost:8086")
 	//
 	opts := write.DefaultOptions().SetRetryInterval(1).SetMaxRetryInterval(10)
 	ctx := context.Background()

--- a/scripts/influxdb-restart.sh
+++ b/scripts/influxdb-restart.sh
@@ -61,17 +61,16 @@ docker run \
        --detach \
        --name influxdb \
        --network influx_network \
-       --publish 8086:8086 \
-       --publish 8089:8089/udp \
+       --publish 8087:8086 \
        --volume ${SCRIPT_PATH}/influxdb.conf:/etc/influxdb/influxdb.conf \
        ${INFLUXDB_IMAGE}
 
 echo "Wait to start InfluxDB"
-wget -S --spider --tries=20 --retry-connrefused --waitretry=5 http://localhost:8086/ping
+wget -S --spider --tries=20 --retry-connrefused --waitretry=5 http://localhost:8087/ping
 echo
 echo "Post with create dabase"
 echo
-curl -X POST localhost:8086/query --data-urlencode "q=create database mydb"
+curl -X POST localhost:8087/query --data-urlencode "q=create database mydb"
 #
 # InfluxDB 2.0
 #
@@ -84,16 +83,16 @@ docker run \
        --detach \
        --name influxdb_v2 \
        --network influx_network \
-       --publish 9999:9999 \
+       --publish 8086:9999 \
        ${INFLUXDB_V2_IMAGE}
 
 echo "Wait to start InfluxDB 2.0"
-wget -S --spider --tries=20 --retry-connrefused --waitretry=5 http://localhost:9999/metrics
+wget -S --spider --tries=20 --retry-connrefused --waitretry=5 http://localhost:8086/metrics
 
 echo
 echo "Post onBoarding request, to setup initial user (my-user@my-password), org (my-org) and bucketSetup (my-bucket)"
 echo
-curl -i -X POST http://localhost:9999/api/v2/setup -H 'accept: application/json' \
+curl -i -X POST http://localhost:8086/api/v2/setup -H 'accept: application/json' \
     -d '{
             "username": "my-user",
             "password": "my-password",
@@ -113,6 +112,6 @@ docker run \
        --detach \
        --name influxdb_v2_onboarding \
        --network influx_network \
-       --publish 9990:9999 \
+       --publish 8089:9999 \
        ${INFLUXDB_V2_IMAGE}
 


### PR DESCRIPTION
Closes #195

## Proposed Changes

Changing server port 9999 -> 8086 in examples and docs.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

