### PR TITLE
feat: Unify type of max field in example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Documentation
 1. [#189](https://github.com/influxdata/influxdb-client-go/pull/189) Added clarification that server URL has to be the InfluxDB server base URL to API docs and all examples.   
+1. [#200](https://github.com/influxdata/influxdb-client-go/pull/200) Fix example code
 
 ## 2.0.1 [2020-08-14]
 ### Bug fixes 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ func main() {
     // Create point using full params constructor 
     p := influxdb2.NewPoint("stat",
         map[string]string{"unit": "temperature"},
-        map[string]interface{}{"avg": 24.5, "max": 45},
+        map[string]interface{}{"avg": 24.5, "max": 45.0},
         time.Now())
     // write point immediately 
     writeAPI.WritePoint(context.Background(), p)
@@ -86,7 +86,7 @@ func main() {
     p = influxdb2.NewPointWithMeasurement("stat").
         AddTag("unit", "temperature").
         AddField("avg", 23.2).
-        AddField("max", 45).
+        AddField("max", 45.0).
         SetTime(time.Now())
     writeAPI.WritePoint(context.Background(), p)
     


### PR DESCRIPTION
avoid 
```field type conflict: input field "max" on measurement "stat" is type float, already exists as type integer dropped=1``` 
error


## Proposed Changes

Update example in README.md

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
