### PR TITLE
fix: write to errCh when point encoding fails

### DIFF
--- a/api/write.go
+++ b/api/write.go
@@ -206,6 +206,9 @@ func (w *WriteAPIImpl) WritePoint(point *write.Point) {
 	line, err := w.service.EncodePoints(point)
 	if err != nil {
 		log.Errorf("point encoding error: %s\n", err.Error())
+		if w.errCh != nil {
+			w.errCh <- err
+		}
 	} else {
 		w.bufferCh <- line
 	}


### PR DESCRIPTION
Closes #

## Proposed Changes

Write the point encoding err to the errCh when the errCh is not nil.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
