### PR TITLE
chore: enabled e2e test

### DIFF
--- a/api/delete_e2e_test.go
+++ b/api/delete_e2e_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestDeleteAPI(t *testing.T) {
-	t.Skip("Skipping due to https://github.com/influxdata/influxdb/issues/19635")
 	ctx := context.Background()
 	client := influxdb2.NewClient(serverURL, authToken)
 	writeAPI := client.WriteAPIBlocking("my-org", "my-bucket")


### PR DESCRIPTION
## Proposed Changes

Enabled e2e test after update InfluxDB to `2.0.3`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
