### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ There are also other examples in the API docs:
 
 1.  Add the client package your to your project dependencies (go.mod).
     ```sh
-    go get github.com/influxdata/influxdb-client-go/v2
+    go get github.com/influxdata/influxdb-client-go
     ```
-1. Add import `github.com/influxdata/influxdb-client-go/v2` to your source code.
+1. Add import `github.com/influxdata/influxdb-client-go` to your source code.
 
 ### Basic Example
 The following example demonstrates how to write data to InfluxDB 2 and read them back using the Flux language:
@@ -71,7 +71,7 @@ import (
     "fmt"
     "time"
 
-    "github.com/influxdata/influxdb-client-go/v2"
+    "github.com/influxdata/influxdb-client-go"
 )
 
 func main() {
@@ -211,7 +211,7 @@ import (
     "math/rand"
     "time"
 
-    "github.com/influxdata/influxdb-client-go/v2"
+    "github.com/influxdata/influxdb-client-go"
 )
 
 func main() {
@@ -262,7 +262,7 @@ import (
     "math/rand"
     "time"
 
-    "github.com/influxdata/influxdb-client-go/v2"
+    "github.com/influxdata/influxdb-client-go"
 )
 
 func main() {
@@ -313,7 +313,7 @@ import (
     "context"
     "fmt"
 
-    "github.com/influxdata/influxdb-client-go/v2"
+    "github.com/influxdata/influxdb-client-go"
 )
 
 func main() {
@@ -356,7 +356,7 @@ import (
     "context"
     "fmt"
 
-    "github.com/influxdata/influxdb-client-go/v2"
+    "github.com/influxdata/influxdb-client-go"
 )
 
 func main() {
@@ -406,7 +406,7 @@ import (
     "fmt"
     "time"
 
-    "github.com/influxdata/influxdb-client-go/v2"
+    "github.com/influxdata/influxdb-client-go"
 )
 
 func main() {


### PR DESCRIPTION
github.com/influxdata/influxdb-client-go/v2 - gives 404, while github.com/influxdata/influxdb-client-go seems to now point to the V2

Closes #

## Proposed Changes

_Briefly describe your proposed changes:_

It seems that reference to github.com/influxdata/influxdb-client-go/v2 is incorrect as it gives 404, while github.com/influxdata/influxdb-client-go looks like pointing to the V2.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
