### PR TITLE
fix: don't attempt retries if MaxRetries is set to zero

### DIFF
--- a/internal/write/service.go
+++ b/internal/write/service.go
@@ -99,7 +99,7 @@ func (w *Service) HandleWrite(ctx context.Context, batch *Batch) error {
 		if batchToWrite != nil {
 			perror := w.WriteBatch(ctx, batchToWrite)
 			if perror != nil {
-				if perror.StatusCode == 0 || perror.StatusCode >= http.StatusTooManyRequests {
+				if w.writeOptions.MaxRetries() != 0 && (perror.StatusCode == 0 || perror.StatusCode >= http.StatusTooManyRequests) {
 					log.Errorf("Write error: %s\nBatch kept for retrying\n", perror.Error())
 					if perror.RetryAfter > 0 {
 						batchToWrite.retryDelay = perror.RetryAfter * 1000


### PR DESCRIPTION
Closes #236 

## Proposed Changes

When a write error occurs, explicitly test for `MaxRetries()` being zero, and do not proceed with retry logic if this is the case.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
