### PR TITLE
fix: Removing retrying from blocking write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.3 [in progress]
+### Bug fixes
+1. [#236](https://github.com/influxdata/influxdb-client-go/pull/236) Setting MaxRetries to zero value disables retry strategy.
+1. [#239](https://github.com/influxdata/influxdb-client-go/pull/239) Blocking write client doesn't use retry handling.  
+
 ## 2.2.2 [2021-01-29]
 ### Bug fixes
 1. [#229](https://github.com/influxdata/influxdb-client-go/pull/229) Connection errors are also subject for retrying.

--- a/api/delete_e2e_test.go
+++ b/api/delete_e2e_test.go
@@ -34,7 +34,7 @@ func TestDeleteAPI(t *testing.T) {
 				map[string]interface{}{"f": f, "i": i},
 				tm)
 			err := writeAPI.WritePoint(ctx, p)
-			require.Nil(t, err, err)
+			require.NoError(t, err)
 			f += 1.2
 			tm = tm.Add(time.Minute)
 		}

--- a/api/http/error.go
+++ b/api/http/error.go
@@ -5,6 +5,7 @@
 package http
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 )
@@ -28,6 +29,10 @@ func (e *Error) Error() string {
 	default:
 		return "Unexpected status code " + strconv.Itoa(e.StatusCode)
 	}
+}
+
+func (e *Error) Unwrap() error {
+	return errors.New(e.Error())
 }
 
 // NewError returns newly created Error initialised with nested error and default values

--- a/api/users_e2e_test.go
+++ b/api/users_e2e_test.go
@@ -170,7 +170,7 @@ func TestSignInOut(t *testing.T) {
 
 	// try authorized calls
 	err = client.WriteAPIBlocking("my-org", "my-bucket").WriteRecord(ctx, "test,a=rock,b=local f=1.2,i=-5i")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	res, err := client.QueryAPI("my-org").QueryRaw(context.Background(), `from(bucket:"my-bucket")|> range(start: -24h) |> filter(fn: (r) => r._measurement == "test")`, influxdb2.DefaultDialect())
 	assert.Nil(t, err)

--- a/api/write/options.go
+++ b/api/write/options.go
@@ -69,7 +69,8 @@ func (o *Options) MaxRetries() uint {
 	return o.maxRetries
 }
 
-// SetMaxRetries sets maximum count of retry attempts of failed writes
+// SetMaxRetries sets maximum count of retry attempts of failed writes.
+// Setting zero value disables retry strategy.
 func (o *Options) SetMaxRetries(maxRetries uint) *Options {
 	o.maxRetries = maxRetries
 	return o

--- a/client_e2e_test.go
+++ b/client_e2e_test.go
@@ -115,7 +115,7 @@ func TestWrite(t *testing.T) {
 
 	err := client.WriteAPIBlocking("my-org", "my-bucket").WritePoint(context.Background(), influxdb2.NewPointWithMeasurement("test").
 		AddTag("a", "3").AddField("i", 20).AddField("f", 4.4))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	client.Close()
 	wg.Wait()
@@ -203,7 +203,7 @@ func TestWriteV1Compatibility(t *testing.T) {
 
 	err := client.WriteAPIBlocking("", "mydb/autogen").WritePoint(context.Background(), influxdb2.NewPointWithMeasurement("testv1").
 		AddTag("a", "3").AddField("i", 20).AddField("f", 4.4))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	client.Close()
 	wg.Wait()
@@ -273,7 +273,7 @@ func TestHTTPService(t *testing.T) {
 	org, err := client.OrganizationsAPI().FindOrganizationByName(context.Background(), "my-org")
 	if err != nil {
 		//return err
-		t.Error(err)
+		t.Fatal(err)
 	}
 	taskDescription := "Example task"
 	taskFlux := `option task = {

--- a/internal/test/generators.go
+++ b/internal/test/generators.go
@@ -1,0 +1,52 @@
+package test
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/influxdata/influxdb-client-go/v2/api/write"
+)
+
+func GenPoints(num int) []*write.Point {
+	points := make([]*write.Point, num)
+	rand.Seed(321)
+
+	t := time.Now()
+	for i := 0; i < len(points); i++ {
+		points[i] = write.NewPoint(
+			"test",
+			map[string]string{
+				"id":       fmt.Sprintf("rack_%v", i%10),
+				"vendor":   "AWS",
+				"hostname": fmt.Sprintf("host_%v", i%100),
+			},
+			map[string]interface{}{
+				"temperature": rand.Float64() * 80.0,
+				"disk_free":   rand.Float64() * 1000.0,
+				"disk_total":  (i/10 + 1) * 1000000,
+				"mem_total":   (i/100 + 1) * 10000000,
+				"mem_free":    rand.Uint64(),
+			},
+			t)
+		if i%10 == 0 {
+			t = t.Add(time.Second)
+		}
+	}
+	return points
+}
+
+func GenRecords(num int) []string {
+	lines := make([]string, num)
+	rand.Seed(321)
+
+	t := time.Now()
+	for i := 0; i < len(lines); i++ {
+		lines[i] = fmt.Sprintf("test,id=rack_%v,vendor=AWS,hostname=host_%v temperature=%v,disk_free=%v,disk_total=%vi,mem_total=%vi,mem_free=%vu %v",
+			i%10, i%100, rand.Float64()*80.0, rand.Float64()*1000.0, (i/10+1)*1000000, (i/100+1)*10000000, rand.Uint64(), t.UnixNano())
+		if i%10 == 0 {
+			t = t.Add(time.Second)
+		}
+	}
+	return lines
+}

--- a/options.go
+++ b/options.go
@@ -61,7 +61,8 @@ func (o *Options) MaxRetries() uint {
 	return o.WriteOptions().MaxRetries()
 }
 
-// SetMaxRetries sets maximum count of retry attempts of failed writes
+// SetMaxRetries sets maximum count of retry attempts of failed writes.
+// Setting zero value disables retry strategy.
 func (o *Options) SetMaxRetries(maxRetries uint) *Options {
 	o.WriteOptions().SetMaxRetries(maxRetries)
 	return o


### PR DESCRIPTION
Closes #235

## Proposed Changes

Blocking write client doesn't use retry handling.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
