### PR TITLE
chore: synced with the latest swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.0 [in progress]
+### Features
+[#241](https://github.com/influxdata/influxdb-client-go/pull/241) Synced with InfluxDB 2.0.5 swagger:
+  - Setup (onboarding) now sends correctly retentionDuration if specified  
+  - `RetentionRule` used in `Bucket` now contains `ShardGroupDurationSeconds` to specify the shard group duration.
+
 ## 2.2.3 [2021-04-01]
 ### Bug fixes
 1. [#236](https://github.com/influxdata/influxdb-client-go/pull/236) Setting MaxRetries to zero value disables retry strategy.

--- a/client.go
+++ b/client.go
@@ -146,17 +146,18 @@ func (c *clientImpl) Ready(ctx context.Context) (bool, error) {
 
 func (c *clientImpl) Setup(ctx context.Context, username, password, org, bucket string, retentionPeriodHours int) (*domain.OnboardingResponse, error) {
 	if username == "" || password == "" {
-		return nil, errors.New("a username and password is required for a setup")
+		return nil, errors.New("a username and a password is required for a setup")
 	}
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	params := &domain.PostSetupParams{}
+	retentionPeriodSeconds := retentionPeriodHours * 3600
 	body := &domain.PostSetupJSONRequestBody{
-		Bucket:             bucket,
-		Org:                org,
-		Password:           &password,
-		RetentionPeriodHrs: &retentionPeriodHours,
-		Username:           username,
+		Bucket:                 bucket,
+		Org:                    org,
+		Password:               &password,
+		RetentionPeriodSeconds: &retentionPeriodSeconds,
+		Username:               username,
 	}
 	response, err := c.apiClient.PostSetupWithResponse(ctx, params, *body)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/influxdata/influxdb-client-go/v2/api"
 	"github.com/influxdata/influxdb-client-go/v2/api/http"
@@ -152,11 +153,13 @@ func (c *clientImpl) Setup(ctx context.Context, username, password, org, bucket 
 	defer c.lock.Unlock()
 	params := &domain.PostSetupParams{}
 	retentionPeriodSeconds := retentionPeriodHours * 3600
+	retentionPeriodHrs := int(time.Duration(retentionPeriodSeconds) * time.Second)
 	body := &domain.PostSetupJSONRequestBody{
 		Bucket:                 bucket,
 		Org:                    org,
 		Password:               &password,
 		RetentionPeriodSeconds: &retentionPeriodSeconds,
+		RetentionPeriodHrs:     &retentionPeriodHrs,
 		Username:               username,
 	}
 	response, err := c.apiClient.PostSetupWithResponse(ctx, params, *body)

--- a/client_e2e_test.go
+++ b/client_e2e_test.go
@@ -44,13 +44,17 @@ func init() {
 
 func TestSetup(t *testing.T) {
 	client := influxdb2.NewClientWithOptions(onboardingURL, "", influxdb2.DefaultOptions().SetLogLevel(2))
-	response, err := client.Setup(context.Background(), "my-user", "my-password", "my-org", "my-bucket", 0)
+	response, err := client.Setup(context.Background(), "my-user", "my-password", "my-org", "my-bucket", 24)
 	if err != nil {
 		t.Error(err)
 	}
 	require.NotNil(t, response)
 	require.NotNil(t, response.Auth)
 	require.NotNil(t, response.Auth.Token)
+	require.NotNil(t, response.Bucket)
+	require.NotNil(t, response.Bucket.RetentionRules)
+	require.Len(t, response.Bucket.RetentionRules, 1)
+	assert.Equal(t, 24*3600, response.Bucket.RetentionRules[0].EverySeconds)
 
 	_, err = client.Setup(context.Background(), "my-user", "my-password", "my-org", "my-bucket", 0)
 	require.NotNil(t, err)

--- a/domain/swagger.yml
+++ b/domain/swagger.yml
@@ -1873,6 +1873,7 @@ paths:
                 $ref: "#/components/schemas/Error"
   /delete:
     post:
+      operationId: PostDelete
       summary: Delete time series data from InfluxDB
       requestBody:
         description: Predicate delete request
@@ -1990,7 +1991,7 @@ paths:
       operationId: PostSources
       tags:
         - Sources
-      summary: Creates a source
+      summary: Create a source
       parameters:
         - $ref: "#/components/parameters/TraceSpan"
       requestBody:
@@ -2814,7 +2815,7 @@ paths:
       operationId: GetDashboardsIDLabels
       tags:
         - Dashboards
-      summary: list all labels for a dashboard
+      summary: List all labels for a dashboard
       parameters:
         - $ref: "#/components/parameters/TraceSpan"
         - in: path
@@ -3305,7 +3306,7 @@ paths:
       operationId: DeleteAuthorizationsID
       tags:
         - Authorizations
-      summary: Delete a authorization
+      summary: Delete an authorization
       parameters:
         - $ref: "#/components/parameters/TraceSpan"
         - in: path
@@ -3681,7 +3682,7 @@ paths:
       operationId: DeleteBucketsIDLabelsID
       tags:
         - Buckets
-      summary: delete a label from a bucket
+      summary: Delete a label from a bucket
       parameters:
         - $ref: "#/components/parameters/TraceSpan"
         - in: path
@@ -4602,7 +4603,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TemplateExport"
+              oneOf:
+                - $ref: "#/components/schemas/TemplateExportByID"
+                - $ref: "#/components/schemas/TemplateExportByName"
       responses:
         "200":
           description: InfluxDB template created
@@ -6746,6 +6749,7 @@ components:
     Expression:
       oneOf:
         - $ref: "#/components/schemas/ArrayExpression"
+        - $ref: "#/components/schemas/DictExpression"
         - $ref: "#/components/schemas/FunctionExpression"
         - $ref: "#/components/schemas/BinaryExpression"
         - $ref: "#/components/schemas/CallExpression"
@@ -6778,6 +6782,27 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Expression"
+    DictExpression:
+      description: Used to create and directly specify the elements of a dictionary
+      type: object
+      properties:
+        type:
+          $ref: "#/components/schemas/NodeType"
+        elements:
+          description: Elements of the dictionary
+          type: array
+          items:
+            $ref: "#/components/schemas/DictItem"
+    DictItem:
+      description: A key/value pair in a dictionary
+      type: object
+      properties:
+        type:
+          $ref: "#/components/schemas/NodeType"
+        key:
+          $ref: "#/components/schemas/Expression"
+        val:
+          $ref: "#/components/schemas/Expression"
     FunctionExpression:
       description: Function expression
       type: object
@@ -7272,9 +7297,13 @@ components:
             - expire
         everySeconds:
           type: integer
-          description: Duration in seconds for how long data will be kept in the database.
+          description: Duration in seconds for how long data will be kept in the database. 0 means infinite.
           example: 86400
-          minimum: 1
+          minimum: 0
+        shardGroupDurationSeconds:
+          type: integer
+          format: int64
+          description: Shard duration measured in seconds.
       required: [type, everySeconds]
     Link:
       type: string
@@ -7475,7 +7504,7 @@ components:
         - Task
         - Telegraf
         - Variable
-    TemplateExport:
+    TemplateExportByID:
       type: object
       properties:
         stackID:
@@ -7507,7 +7536,39 @@ components:
               $ref: "#/components/schemas/TemplateKind"
             name:
               type: string
+              description: "if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported"
           required: [id, kind]
+    TemplateExportByName:
+      type: object
+      properties:
+        stackID:
+          type: string
+        orgIDs:
+          type: array
+          items:
+            type: object
+            properties:
+              orgID:
+                type: string
+              resourceFilters:
+                type: object
+                properties:
+                  byLabel:
+                    type: array
+                    items:
+                      type: string
+                  byResourceKind:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TemplateKind"
+        resources:
+          type: object
+          properties:
+            kind:
+              $ref: "#/components/schemas/TemplateKind"
+            name:
+              type: string
+          required: [name, kind]
     Template:
       type: array
       items:
@@ -8445,45 +8506,6 @@ components:
     TaskStatusType:
       type: string
       enum: [active, inactive]
-    Invite:
-      properties:
-        id:
-          description: the idpe id of the invite
-          readOnly: true
-          type: string
-        email:
-          type: string
-        role:
-          type: string
-          enum:
-            - member
-            - owner
-        expiresAt:
-          format: date-time
-          type: string
-        links:
-          type: object
-          readOnly: true
-          example:
-            self: "/api/v2/invites/1"
-          properties:
-            self:
-              type: string
-              format: uri
-      required: [id, email, role]
-    Invites:
-      type: object
-      properties:
-        links:
-          type: object
-          properties:
-            self:
-              type: string
-              format: uri
-        invites:
-          type: array
-          items:
-            $ref: "#/components/schemas/Invite"
     User:
       properties:
         id:
@@ -8944,8 +8966,32 @@ components:
           $ref: "#/components/schemas/Legend"
         xColumn:
           type: string
+        generateXAxisTicks:
+          type: array
+          items:
+            type: string
+        xTotalTicks:
+          type: integer
+        xTickStart:
+          type: number
+          format: float
+        xTickStep:
+          type: number
+          format: float
         yColumn:
           type: string
+        generateYAxisTicks:
+          type: array
+          items:
+            type: string
+        yTotalTicks:
+          type: integer
+        yTickStart:
+          type: number
+          format: float
+        yTickStep:
+          type: number
+          format: float
         shadeBelow:
           type: boolean
         hoverDimension:
@@ -8956,6 +9002,8 @@ components:
           enum: [overlaid, stacked]
         geom:
           $ref: "#/components/schemas/XYGeom"
+        legendColorizeRows:
+          type: boolean
         legendOpacity:
           type: number
           format: float
@@ -9005,8 +9053,32 @@ components:
           $ref: "#/components/schemas/Legend"
         xColumn:
           type: string
+        generateXAxisTicks:
+          type: array
+          items:
+            type: string
+        xTotalTicks:
+          type: integer
+        xTickStart:
+          type: number
+          format: float
+        xTickStep:
+          type: number
+          format: float
         yColumn:
           type: string
+        generateYAxisTicks:
+          type: array
+          items:
+            type: string
+        yTotalTicks:
+          type: integer
+        yTickStart:
+          type: number
+          format: float
+        yTickStep:
+          type: number
+          format: float
         upperColumn:
           type: string
         mainColumn:
@@ -9018,6 +9090,8 @@ components:
           enum: [auto, x, y, xy]
         geom:
           $ref: "#/components/schemas/XYGeom"
+        legendColorizeRows:
+          type: boolean
         legendOpacity:
           type: number
           format: float
@@ -9067,8 +9141,32 @@ components:
           $ref: "#/components/schemas/Legend"
         xColumn:
           type: string
+        generateXAxisTicks:
+          type: array
+          items:
+            type: string
+        xTotalTicks:
+          type: integer
+        xTickStart:
+          type: number
+          format: float
+        xTickStep:
+          type: number
+          format: float
         yColumn:
           type: string
+        generateYAxisTicks:
+          type: array
+          items:
+            type: string
+        yTotalTicks:
+          type: integer
+        yTickStart:
+          type: number
+          format: float
+        yTickStep:
+          type: number
+          format: float
         shadeBelow:
           type: boolean
         hoverDimension:
@@ -9083,6 +9181,8 @@ components:
           type: string
         decimalPlaces:
           $ref: "#/components/schemas/DecimalPlaces"
+        legendColorizeRows:
+          type: boolean
         legendOpacity:
           type: number
           format: float
@@ -9133,6 +9233,24 @@ components:
           type: boolean
         xColumn:
           type: string
+        generateXAxisTicks:
+          type: array
+          items:
+            type: string
+        xTotalTicks:
+          type: integer
+        xTickStart:
+          type: number
+          format: float
+        xTickStep:
+          type: number
+          format: float
+        yLabelColumnSeparator:
+          type: string
+        yLabelColumns:
+          type: array
+          items:
+            type: string
         ySeriesColumns:
           type: array
           items:
@@ -9163,6 +9281,11 @@ components:
           type: string
         ySuffix:
           type: string
+        hoverDimension:
+          type: string
+          enum: [auto, x, y, xy]
+        legendColorizeRows:
+          type: boolean
         legendOpacity:
           type: number
           format: float
@@ -9214,8 +9337,32 @@ components:
           type: boolean
         xColumn:
           type: string
+        generateXAxisTicks:
+          type: array
+          items:
+            type: string
+        xTotalTicks:
+          type: integer
+        xTickStart:
+          type: number
+          format: float
+        xTickStep:
+          type: number
+          format: float
         yColumn:
           type: string
+        generateYAxisTicks:
+          type: array
+          items:
+            type: string
+        yTotalTicks:
+          type: integer
+        yTickStart:
+          type: number
+          format: float
+        yTickStep:
+          type: number
+          format: float
         fillColumns:
           type: array
           items:
@@ -9246,6 +9393,8 @@ components:
           type: string
         ySuffix:
           type: string
+        legendColorizeRows:
+          type: boolean
         legendOpacity:
           type: number
           format: float
@@ -9296,8 +9445,32 @@ components:
           type: boolean
         xColumn:
           type: string
+        generateXAxisTicks:
+          type: array
+          items:
+            type: string
+        xTotalTicks:
+          type: integer
+        xTickStart:
+          type: number
+          format: float
+        xTickStep:
+          type: number
+          format: float
         yColumn:
           type: string
+        generateYAxisTicks:
+          type: array
+          items:
+            type: string
+        yTotalTicks:
+          type: integer
+        yTickStart:
+          type: number
+          format: float
+        yTickStep:
+          type: number
+          format: float
         xDomain:
           type: array
           items:
@@ -9322,6 +9495,8 @@ components:
           type: string
         binSize:
           type: number
+        legendColorizeRows:
+          type: boolean
         legendOpacity:
           type: number
           format: float
@@ -9375,11 +9550,6 @@ components:
           $ref: "#/components/schemas/Legend"
         decimalPlaces:
           $ref: "#/components/schemas/DecimalPlaces"
-        legendOpacity:
-          type: number
-          format: float
-        legendOrientationThreshold:
-          type: integer
     HistogramViewProperties:
       type: object
       required:
@@ -9434,6 +9604,8 @@ components:
           enum: [overlaid, stacked]
         binCount:
           type: integer
+        legendColorizeRows:
+          type: boolean
         legendOpacity:
           type: number
           format: float
@@ -9601,11 +9773,174 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DashboardColor"
+        legendColorizeRows:
+          type: boolean
         legendOpacity:
           type: number
           format: float
         legendOrientationThreshold:
           type: integer
+    GeoViewLayer:
+      type: object
+      oneOf:
+        - $ref: "#/components/schemas/GeoCircleViewLayer"
+        - $ref: "#/components/schemas/GeoHeatMapViewLayer"
+        - $ref: "#/components/schemas/GeoPointMapViewLayer"
+        - $ref: "#/components/schemas/GeoTrackMapViewLayer"
+    GeoViewLayerProperties:
+      type: object
+      required: [type]
+      properties:
+        type:
+          type: string
+          enum: [heatmap, circleMap, pointMap, trackMap]
+    GeoCircleViewLayer:
+      allOf:
+        - $ref: "#/components/schemas/GeoViewLayerProperties"
+        - type: object
+          required: [radiusField, radiusDimension, colorField, colorDimension, colors]
+          properties:
+            radiusField:
+              type: string
+              description: Radius field
+            radiusDimension:
+              $ref: '#/components/schemas/Axis'
+            colorField:
+              type: string
+              description: Circle color field
+            colorDimension:
+              $ref: '#/components/schemas/Axis'
+            colors:
+              description: Colors define color encoding of data into a visualization
+              type: array
+              items:
+                $ref: "#/components/schemas/DashboardColor"
+            radius:
+              description: Maximum radius size in pixels
+              type: integer
+            interpolateColors:
+              description: Interpolate circle color based on displayed value
+              type: boolean
+    GeoPointMapViewLayer:
+      allOf:
+        - $ref: "#/components/schemas/GeoViewLayerProperties"
+        - type: object
+          required: [colorField, colorDimension, colors]
+          properties:
+            colorField:
+              type: string
+              description: Marker color field
+            colorDimension:
+              $ref: '#/components/schemas/Axis'
+            colors:
+              description: Colors define color encoding of data into a visualization
+              type: array
+              items:
+                $ref: "#/components/schemas/DashboardColor"
+            isClustered:
+              description: Cluster close markers together
+              type: boolean
+    GeoTrackMapViewLayer:
+      allOf:
+        - $ref: "#/components/schemas/GeoViewLayerProperties"
+        - type: object
+          required: [trackWidth, speed, randomColors, trackPointVisualization]
+      properties:
+        trackWidth:
+          description: Width of the track
+          type: integer
+        speed:
+          description: Speed of the track animation
+          type: integer
+        randomColors:
+          description: Assign different colors to different tracks
+          type: boolean
+        colors:
+          description: Colors define color encoding of data into a visualization
+          type: array
+          items:
+             $ref: "#/components/schemas/DashboardColor"
+    GeoHeatMapViewLayer:
+      allOf:
+        - $ref: "#/components/schemas/GeoViewLayerProperties"
+        - type: object
+          required: [intensityField, intensityDimension, radius, blur, colors]
+          properties:
+            intensityField:
+              type: string
+              description: Intensity field
+            intensityDimension:
+              $ref: '#/components/schemas/Axis'
+            radius:
+              description: Radius size in pixels
+              type: integer
+            blur:
+              description: Blur for heatmap points
+              type: integer
+            colors:
+              description: Colors define color encoding of data into a visualization
+              type: array
+              items:
+                $ref: "#/components/schemas/DashboardColor"
+    GeoViewProperties:
+      type: object
+      required: [type, shape, queries, note, showNoteWhenEmpty, center, zoom, allowPanAndZoom, detectCoordinateFields, layers]
+      properties:
+        type:
+          type: string
+          enum: [geo]
+        queries:
+          type: array
+          items:
+            $ref: "#/components/schemas/DashboardQuery"
+        shape:
+          type: string
+          enum: ['chronograf-v2']
+        center:
+          description: Coordinates of the center of the map
+          type: object
+          required: [lat, lon]
+          properties:
+            lat:
+              description: Latitude of the center of the map
+              type: number
+              format: double
+            lon:
+              description: Longitude of the center of the map
+              type: number
+              format: double
+        zoom:
+          description: Zoom level used for initial display of the map
+          type: number
+          format: double
+          minimum: 1
+          maximum: 28
+        allowPanAndZoom:
+          description: If true, map zoom and pan controls are enabled on the dashboard view
+          type: boolean
+          default: true
+        detectCoordinateFields:
+          description: If true, search results get automatically regroupped so that lon,lat and value are treated as columns
+          type: boolean
+          default: true
+        mapStyle:
+          description: Define map type - regular, satellite etc.
+          type: string
+        note:
+          type: string
+        showNoteWhenEmpty:
+          description: If true, will display note when empty
+          type: boolean
+        colors:
+          description: Colors define color encoding of data into a visualization
+          type: array
+          items:
+            $ref: "#/components/schemas/DashboardColor"
+        layers:
+          description: List of individual layers shown in the map
+          type: array
+          items:
+            $ref: "#/components/schemas/GeoViewLayer"
     Axes:
       description: The viewport for a View's visualizations
       type: object
@@ -9777,6 +10112,7 @@ components:
         - $ref: "#/components/schemas/HeatmapViewProperties"
         - $ref: "#/components/schemas/MosaicViewProperties"
         - $ref: "#/components/schemas/BandViewProperties"
+        - $ref: "#/components/schemas/GeoViewProperties"
     View:
       required:
         - name
@@ -10125,6 +10461,10 @@ components:
         bucketID:
           type: string
           description: The ID of the bucket to write to.
+        allowInsecure:
+          type: boolean
+          description: Skip TLS verification on endpoint.
+          default: false
     ScraperTargetResponse:
       type: object
       allOf:
@@ -10807,8 +11147,14 @@ components:
           type: string
         bucket:
           type: string
+        retentionPeriodSeconds:
+          type: integer
         retentionPeriodHrs:
           type: integer
+          deprecated: true
+          description: >
+            Retention period *in nanoseconds* for the new bucket. This key's name has been misleading since OSS 2.0 GA,
+            please transition to use `retentionPeriodSeconds`
       required:
         - username
         - org
@@ -11670,12 +12016,7 @@ components:
       type: string
       enum: ["slack", "pagerduty", "http", "telegram"]
     DBRP:
-      required:
-        - orgID
-        - org
-        - bucketID
-        - database
-        - retention_policy
+      type: object
       properties:
         id:
           type: string
@@ -11701,14 +12042,23 @@ components:
           description: Specify if this mapping represents the default retention policy for the database specificed.
         links:
           $ref: "#/components/schemas/Links"
+      oneOf:
+        - required:
+          - orgID
+          - bucketID
+          - database
+          - retention_policy
+        - required:
+          - org
+          - bucketID
+          - database
+          - retention_policy
     DBRPs:
       properties:
-        notificationEndpoints:
+        content:
           type: array
           items:
             $ref: "#/components/schemas/DBRP"
-        links:
-          $ref: "#/components/schemas/Links"
     DBRPUpdate:
       properties:
         database:

--- a/domain/types.gen.go
+++ b/domain/types.gen.go
@@ -204,6 +204,27 @@ const (
 	GaugeViewPropertiesTypeGauge GaugeViewPropertiesType = "gauge"
 )
 
+// Defines values for GeoViewLayerPropertiesType.
+const (
+	GeoViewLayerPropertiesTypeCircleMap GeoViewLayerPropertiesType = "circleMap"
+
+	GeoViewLayerPropertiesTypeHeatmap GeoViewLayerPropertiesType = "heatmap"
+
+	GeoViewLayerPropertiesTypePointMap GeoViewLayerPropertiesType = "pointMap"
+
+	GeoViewLayerPropertiesTypeTrackMap GeoViewLayerPropertiesType = "trackMap"
+)
+
+// Defines values for GeoViewPropertiesShape.
+const (
+	GeoViewPropertiesShapeChronografV2 GeoViewPropertiesShape = "chronograf-v2"
+)
+
+// Defines values for GeoViewPropertiesType.
+const (
+	GeoViewPropertiesTypeGeo GeoViewPropertiesType = "geo"
+)
+
 // Defines values for GreaterThresholdType.
 const (
 	GreaterThresholdTypeGreater GreaterThresholdType = "greater"
@@ -353,6 +374,17 @@ const (
 // Defines values for MarkdownViewPropertiesType.
 const (
 	MarkdownViewPropertiesTypeMarkdown MarkdownViewPropertiesType = "markdown"
+)
+
+// Defines values for MosaicViewPropertiesHoverDimension.
+const (
+	MosaicViewPropertiesHoverDimensionAuto MosaicViewPropertiesHoverDimension = "auto"
+
+	MosaicViewPropertiesHoverDimensionTrue MosaicViewPropertiesHoverDimension = "true"
+
+	MosaicViewPropertiesHoverDimensionX MosaicViewPropertiesHoverDimension = "x"
+
+	MosaicViewPropertiesHoverDimensionXy MosaicViewPropertiesHoverDimension = "xy"
 )
 
 // Defines values for MosaicViewPropertiesShape.
@@ -883,12 +915,15 @@ type BandViewProperties struct {
 	Axes Axes `json:"axes"`
 
 	// Colors define color encoding of data into a visualization
-	Colors         []DashboardColor                  `json:"colors"`
-	Geom           XYGeom                            `json:"geom"`
-	HoverDimension *BandViewPropertiesHoverDimension `json:"hoverDimension,omitempty"`
+	Colors             []DashboardColor                  `json:"colors"`
+	GenerateXAxisTicks *[]string                         `json:"generateXAxisTicks,omitempty"`
+	GenerateYAxisTicks *[]string                         `json:"generateYAxisTicks,omitempty"`
+	Geom               XYGeom                            `json:"geom"`
+	HoverDimension     *BandViewPropertiesHoverDimension `json:"hoverDimension,omitempty"`
 
 	// Legend define encoding of data into a view's legend
 	Legend                     Legend                  `json:"legend"`
+	LegendColorizeRows         *bool                   `json:"legendColorizeRows,omitempty"`
 	LegendOpacity              *float32                `json:"legendOpacity,omitempty"`
 	LegendOrientationThreshold *int                    `json:"legendOrientationThreshold,omitempty"`
 	LowerColumn                *string                 `json:"lowerColumn,omitempty"`
@@ -903,7 +938,13 @@ type BandViewProperties struct {
 	Type              BandViewPropertiesType `json:"type"`
 	UpperColumn       *string                `json:"upperColumn,omitempty"`
 	XColumn           *string                `json:"xColumn,omitempty"`
+	XTickStart        *float32               `json:"xTickStart,omitempty"`
+	XTickStep         *float32               `json:"xTickStep,omitempty"`
+	XTotalTicks       *int                   `json:"xTotalTicks,omitempty"`
 	YColumn           *string                `json:"yColumn,omitempty"`
+	YTickStart        *float32               `json:"yTickStart,omitempty"`
+	YTickStep         *float32               `json:"yTickStep,omitempty"`
+	YTotalTicks       *int                   `json:"yTotalTicks,omitempty"`
 }
 
 // BandViewPropertiesHoverDimension defines model for BandViewProperties.HoverDimension.
@@ -1148,6 +1189,7 @@ type CheckViewProperties struct {
 
 	// Colors define color encoding of data into a visualization
 	Colors                     []DashboardColor         `json:"colors"`
+	LegendColorizeRows         *bool                    `json:"legendColorizeRows,omitempty"`
 	LegendOpacity              *float32                 `json:"legendOpacity,omitempty"`
 	LegendOrientationThreshold *int                     `json:"legendOrientationThreshold,omitempty"`
 	Queries                    []DashboardQuery         `json:"queries"`
@@ -1223,30 +1265,7 @@ type CustomCheck struct {
 type CustomCheckType string
 
 // DBRP defines model for DBRP.
-type DBRP struct {
-
-	// the bucket ID used as target for the translation.
-	BucketID string `json:"bucketID"`
-
-	// InfluxDB v1 database
-	Database string `json:"database"`
-
-	// Specify if this mapping represents the default retention policy for the database specificed.
-	Default *bool `json:"default,omitempty"`
-
-	// the mapping identifier
-	Id    *string `json:"id,omitempty"`
-	Links *Links  `json:"links,omitempty"`
-
-	// the organization that owns this mapping.
-	Org string `json:"org"`
-
-	// the organization ID that owns this mapping.
-	OrgID string `json:"orgID"`
-
-	// InfluxDB v1 retention policy
-	RetentionPolicy string `json:"retention_policy"`
-}
+type DBRP interface{}
 
 // DBRPUpdate defines model for DBRPUpdate.
 type DBRPUpdate struct {
@@ -1262,8 +1281,7 @@ type DBRPUpdate struct {
 
 // DBRPs defines model for DBRPs.
 type DBRPs struct {
-	Links                 *Links  `json:"links,omitempty"`
-	NotificationEndpoints *[]DBRP `json:"notificationEndpoints,omitempty"`
+	Content *[]DBRP `json:"content,omitempty"`
 }
 
 // Dashboard defines model for Dashboard.
@@ -1465,6 +1483,25 @@ type DialectAnnotations string
 
 // DialectDateTimeFormat defines model for Dialect.DateTimeFormat.
 type DialectDateTimeFormat string
+
+// DictExpression defines model for DictExpression.
+type DictExpression struct {
+
+	// Elements of the dictionary
+	Elements *[]DictItem `json:"elements,omitempty"`
+
+	// Type of AST node
+	Type *NodeType `json:"type,omitempty"`
+}
+
+// DictItem defines model for DictItem.
+type DictItem struct {
+	Key *Expression `json:"key,omitempty"`
+
+	// Type of AST node
+	Type *NodeType   `json:"type,omitempty"`
+	Val  *Expression `json:"val,omitempty"`
+}
 
 // Document defines model for Document.
 type Document struct {
@@ -1684,6 +1721,138 @@ type GaugeViewPropertiesShape string
 // GaugeViewPropertiesType defines model for GaugeViewProperties.Type.
 type GaugeViewPropertiesType string
 
+// GeoCircleViewLayer defines model for GeoCircleViewLayer.
+type GeoCircleViewLayer struct {
+	// Embedded struct due to allOf(#/components/schemas/GeoViewLayerProperties)
+	GeoViewLayerProperties
+	// Embedded fields due to inline allOf schema
+
+	// The description of a particular axis for a visualization.
+	ColorDimension Axis `json:"colorDimension"`
+
+	// Circle color field
+	ColorField string `json:"colorField"`
+
+	// Colors define color encoding of data into a visualization
+	Colors []DashboardColor `json:"colors"`
+
+	// Interpolate circle color based on displayed value
+	InterpolateColors *bool `json:"interpolateColors,omitempty"`
+
+	// Maximum radius size in pixels
+	Radius *int `json:"radius,omitempty"`
+
+	// The description of a particular axis for a visualization.
+	RadiusDimension Axis `json:"radiusDimension"`
+
+	// Radius field
+	RadiusField string `json:"radiusField"`
+}
+
+// GeoHeatMapViewLayer defines model for GeoHeatMapViewLayer.
+type GeoHeatMapViewLayer struct {
+	// Embedded struct due to allOf(#/components/schemas/GeoViewLayerProperties)
+	GeoViewLayerProperties
+	// Embedded fields due to inline allOf schema
+
+	// Blur for heatmap points
+	Blur int `json:"blur"`
+
+	// Colors define color encoding of data into a visualization
+	Colors []DashboardColor `json:"colors"`
+
+	// The description of a particular axis for a visualization.
+	IntensityDimension Axis `json:"intensityDimension"`
+
+	// Intensity field
+	IntensityField string `json:"intensityField"`
+
+	// Radius size in pixels
+	Radius int `json:"radius"`
+}
+
+// GeoPointMapViewLayer defines model for GeoPointMapViewLayer.
+type GeoPointMapViewLayer struct {
+	// Embedded struct due to allOf(#/components/schemas/GeoViewLayerProperties)
+	GeoViewLayerProperties
+	// Embedded fields due to inline allOf schema
+
+	// The description of a particular axis for a visualization.
+	ColorDimension Axis `json:"colorDimension"`
+
+	// Marker color field
+	ColorField string `json:"colorField"`
+
+	// Colors define color encoding of data into a visualization
+	Colors []DashboardColor `json:"colors"`
+
+	// Cluster close markers together
+	IsClustered *bool `json:"isClustered,omitempty"`
+}
+
+// GeoTrackMapViewLayer defines model for GeoTrackMapViewLayer.
+type GeoTrackMapViewLayer struct {
+	// Embedded struct due to allOf(#/components/schemas/GeoViewLayerProperties)
+	GeoViewLayerProperties
+	// Embedded fields due to inline allOf schema
+}
+
+// GeoViewLayer defines model for GeoViewLayer.
+type GeoViewLayer interface{}
+
+// GeoViewLayerProperties defines model for GeoViewLayerProperties.
+type GeoViewLayerProperties struct {
+	Type GeoViewLayerPropertiesType `json:"type"`
+}
+
+// GeoViewLayerPropertiesType defines model for GeoViewLayerProperties.Type.
+type GeoViewLayerPropertiesType string
+
+// GeoViewProperties defines model for GeoViewProperties.
+type GeoViewProperties struct {
+
+	// If true, map zoom and pan controls are enabled on the dashboard view
+	AllowPanAndZoom bool `json:"allowPanAndZoom"`
+
+	// Coordinates of the center of the map
+	Center struct {
+
+		// Latitude of the center of the map
+		Lat float64 `json:"lat"`
+
+		// Longitude of the center of the map
+		Lon float64 `json:"lon"`
+	} `json:"center"`
+
+	// Colors define color encoding of data into a visualization
+	Colors *[]DashboardColor `json:"colors,omitempty"`
+
+	// If true, search results get automatically regroupped so that lon,lat and value are treated as columns
+	DetectCoordinateFields bool `json:"detectCoordinateFields"`
+
+	// List of individual layers shown in the map
+	Layers []GeoViewLayer `json:"layers"`
+
+	// Define map type - regular, satellite etc.
+	MapStyle *string                `json:"mapStyle,omitempty"`
+	Note     string                 `json:"note"`
+	Queries  []DashboardQuery       `json:"queries"`
+	Shape    GeoViewPropertiesShape `json:"shape"`
+
+	// If true, will display note when empty
+	ShowNoteWhenEmpty bool                  `json:"showNoteWhenEmpty"`
+	Type              GeoViewPropertiesType `json:"type"`
+
+	// Zoom level used for initial display of the map
+	Zoom float64 `json:"zoom"`
+}
+
+// GeoViewPropertiesShape defines model for GeoViewProperties.Shape.
+type GeoViewPropertiesShape string
+
+// GeoViewPropertiesType defines model for GeoViewProperties.Type.
+type GeoViewPropertiesType string
+
 // GreaterThreshold defines model for GreaterThreshold.
 type GreaterThreshold struct {
 	// Embedded struct due to allOf(#/components/schemas/ThresholdBase)
@@ -1760,6 +1929,9 @@ type HeatmapViewProperties struct {
 
 	// Colors define color encoding of data into a visualization
 	Colors                     []string                   `json:"colors"`
+	GenerateXAxisTicks         *[]string                  `json:"generateXAxisTicks,omitempty"`
+	GenerateYAxisTicks         *[]string                  `json:"generateYAxisTicks,omitempty"`
+	LegendColorizeRows         *bool                      `json:"legendColorizeRows,omitempty"`
 	LegendOpacity              *float32                   `json:"legendOpacity,omitempty"`
 	LegendOrientationThreshold *int                       `json:"legendOrientationThreshold,omitempty"`
 	Note                       string                     `json:"note"`
@@ -1775,11 +1947,17 @@ type HeatmapViewProperties struct {
 	XDomain           []float32                 `json:"xDomain"`
 	XPrefix           string                    `json:"xPrefix"`
 	XSuffix           string                    `json:"xSuffix"`
+	XTickStart        *float32                  `json:"xTickStart,omitempty"`
+	XTickStep         *float32                  `json:"xTickStep,omitempty"`
+	XTotalTicks       *int                      `json:"xTotalTicks,omitempty"`
 	YAxisLabel        string                    `json:"yAxisLabel"`
 	YColumn           string                    `json:"yColumn"`
 	YDomain           []float32                 `json:"yDomain"`
 	YPrefix           string                    `json:"yPrefix"`
 	YSuffix           string                    `json:"ySuffix"`
+	YTickStart        *float32                  `json:"yTickStart,omitempty"`
+	YTickStep         *float32                  `json:"yTickStep,omitempty"`
+	YTotalTicks       *int                      `json:"yTotalTicks,omitempty"`
 }
 
 // HeatmapViewPropertiesShape defines model for HeatmapViewProperties.Shape.
@@ -1795,6 +1973,7 @@ type HistogramViewProperties struct {
 	// Colors define color encoding of data into a visualization
 	Colors                     []DashboardColor                `json:"colors"`
 	FillColumns                []string                        `json:"fillColumns"`
+	LegendColorizeRows         *bool                           `json:"legendColorizeRows,omitempty"`
 	LegendOpacity              *float32                        `json:"legendOpacity,omitempty"`
 	LegendOrientationThreshold *int                            `json:"legendOrientationThreshold,omitempty"`
 	Note                       string                          `json:"note"`
@@ -1987,11 +2166,14 @@ type LinePlusSingleStatProperties struct {
 	Colors []DashboardColor `json:"colors"`
 
 	// Indicates whether decimal places should be enforced, and how many digits it should show.
-	DecimalPlaces  DecimalPlaces                               `json:"decimalPlaces"`
-	HoverDimension *LinePlusSingleStatPropertiesHoverDimension `json:"hoverDimension,omitempty"`
+	DecimalPlaces      DecimalPlaces                               `json:"decimalPlaces"`
+	GenerateXAxisTicks *[]string                                   `json:"generateXAxisTicks,omitempty"`
+	GenerateYAxisTicks *[]string                                   `json:"generateYAxisTicks,omitempty"`
+	HoverDimension     *LinePlusSingleStatPropertiesHoverDimension `json:"hoverDimension,omitempty"`
 
 	// Legend define encoding of data into a view's legend
 	Legend                     Legend                               `json:"legend"`
+	LegendColorizeRows         *bool                                `json:"legendColorizeRows,omitempty"`
 	LegendOpacity              *float32                             `json:"legendOpacity,omitempty"`
 	LegendOrientationThreshold *int                                 `json:"legendOrientationThreshold,omitempty"`
 	Note                       string                               `json:"note"`
@@ -2007,7 +2189,13 @@ type LinePlusSingleStatProperties struct {
 	TimeFormat        *string                          `json:"timeFormat,omitempty"`
 	Type              LinePlusSingleStatPropertiesType `json:"type"`
 	XColumn           *string                          `json:"xColumn,omitempty"`
+	XTickStart        *float32                         `json:"xTickStart,omitempty"`
+	XTickStep         *float32                         `json:"xTickStep,omitempty"`
+	XTotalTicks       *int                             `json:"xTotalTicks,omitempty"`
 	YColumn           *string                          `json:"yColumn,omitempty"`
+	YTickStart        *float32                         `json:"yTickStart,omitempty"`
+	YTickStep         *float32                         `json:"yTickStep,omitempty"`
+	YTotalTicks       *int                             `json:"yTotalTicks,omitempty"`
 }
 
 // LinePlusSingleStatPropertiesHoverDimension defines model for LinePlusSingleStatProperties.HoverDimension.
@@ -2152,29 +2340,40 @@ type MemberExpression struct {
 type MosaicViewProperties struct {
 
 	// Colors define color encoding of data into a visualization
-	Colors                     []string                  `json:"colors"`
-	FillColumns                []string                  `json:"fillColumns"`
-	LegendOpacity              *float32                  `json:"legendOpacity,omitempty"`
-	LegendOrientationThreshold *int                      `json:"legendOrientationThreshold,omitempty"`
-	Note                       string                    `json:"note"`
-	Queries                    []DashboardQuery          `json:"queries"`
-	Shape                      MosaicViewPropertiesShape `json:"shape"`
+	Colors                     []string                            `json:"colors"`
+	FillColumns                []string                            `json:"fillColumns"`
+	GenerateXAxisTicks         *[]string                           `json:"generateXAxisTicks,omitempty"`
+	HoverDimension             *MosaicViewPropertiesHoverDimension `json:"hoverDimension,omitempty"`
+	LegendColorizeRows         *bool                               `json:"legendColorizeRows,omitempty"`
+	LegendOpacity              *float32                            `json:"legendOpacity,omitempty"`
+	LegendOrientationThreshold *int                                `json:"legendOrientationThreshold,omitempty"`
+	Note                       string                              `json:"note"`
+	Queries                    []DashboardQuery                    `json:"queries"`
+	Shape                      MosaicViewPropertiesShape           `json:"shape"`
 
 	// If true, will display note when empty
-	ShowNoteWhenEmpty bool                     `json:"showNoteWhenEmpty"`
-	TimeFormat        *string                  `json:"timeFormat,omitempty"`
-	Type              MosaicViewPropertiesType `json:"type"`
-	XAxisLabel        string                   `json:"xAxisLabel"`
-	XColumn           string                   `json:"xColumn"`
-	XDomain           []float32                `json:"xDomain"`
-	XPrefix           string                   `json:"xPrefix"`
-	XSuffix           string                   `json:"xSuffix"`
-	YAxisLabel        string                   `json:"yAxisLabel"`
-	YDomain           []float32                `json:"yDomain"`
-	YPrefix           string                   `json:"yPrefix"`
-	YSeriesColumns    []string                 `json:"ySeriesColumns"`
-	YSuffix           string                   `json:"ySuffix"`
+	ShowNoteWhenEmpty     bool                     `json:"showNoteWhenEmpty"`
+	TimeFormat            *string                  `json:"timeFormat,omitempty"`
+	Type                  MosaicViewPropertiesType `json:"type"`
+	XAxisLabel            string                   `json:"xAxisLabel"`
+	XColumn               string                   `json:"xColumn"`
+	XDomain               []float32                `json:"xDomain"`
+	XPrefix               string                   `json:"xPrefix"`
+	XSuffix               string                   `json:"xSuffix"`
+	XTickStart            *float32                 `json:"xTickStart,omitempty"`
+	XTickStep             *float32                 `json:"xTickStep,omitempty"`
+	XTotalTicks           *int                     `json:"xTotalTicks,omitempty"`
+	YAxisLabel            string                   `json:"yAxisLabel"`
+	YDomain               []float32                `json:"yDomain"`
+	YLabelColumnSeparator *string                  `json:"yLabelColumnSeparator,omitempty"`
+	YLabelColumns         *[]string                `json:"yLabelColumns,omitempty"`
+	YPrefix               string                   `json:"yPrefix"`
+	YSeriesColumns        []string                 `json:"ySeriesColumns"`
+	YSuffix               string                   `json:"ySuffix"`
 }
+
+// MosaicViewPropertiesHoverDimension defines model for MosaicViewProperties.HoverDimension.
+type MosaicViewPropertiesHoverDimension string
 
 // MosaicViewPropertiesShape defines model for MosaicViewProperties.Shape.
 type MosaicViewPropertiesShape string
@@ -2355,11 +2554,14 @@ type ObjectExpression struct {
 
 // OnboardingRequest defines model for OnboardingRequest.
 type OnboardingRequest struct {
-	Bucket             string  `json:"bucket"`
-	Org                string  `json:"org"`
-	Password           *string `json:"password,omitempty"`
-	RetentionPeriodHrs *int    `json:"retentionPeriodHrs,omitempty"`
-	Username           string  `json:"username"`
+	Bucket   string  `json:"bucket"`
+	Org      string  `json:"org"`
+	Password *string `json:"password,omitempty"`
+
+	// Retention period *in nanoseconds* for the new bucket. This key's name has been misleading since OSS 2.0 GA, please transition to use `retentionPeriodSeconds`
+	RetentionPeriodHrs     *int   `json:"retentionPeriodHrs,omitempty"`
+	RetentionPeriodSeconds *int   `json:"retentionPeriodSeconds,omitempty"`
+	Username               string `json:"username"`
 }
 
 // OnboardingResponse defines model for OnboardingResponse.
@@ -2701,9 +2903,12 @@ type ResourceOwners struct {
 // RetentionRule defines model for RetentionRule.
 type RetentionRule struct {
 
-	// Duration in seconds for how long data will be kept in the database.
-	EverySeconds int               `json:"everySeconds"`
-	Type         RetentionRuleType `json:"type"`
+	// Duration in seconds for how long data will be kept in the database. 0 means infinite.
+	EverySeconds int `json:"everySeconds"`
+
+	// Shard duration measured in seconds.
+	ShardGroupDurationSeconds *int64            `json:"shardGroupDurationSeconds,omitempty"`
+	Type                      RetentionRuleType `json:"type"`
 }
 
 // RetentionRuleType defines model for RetentionRule.Type.
@@ -2828,6 +3033,9 @@ type ScatterViewProperties struct {
 	// Colors define color encoding of data into a visualization
 	Colors                     []string                   `json:"colors"`
 	FillColumns                []string                   `json:"fillColumns"`
+	GenerateXAxisTicks         *[]string                  `json:"generateXAxisTicks,omitempty"`
+	GenerateYAxisTicks         *[]string                  `json:"generateYAxisTicks,omitempty"`
+	LegendColorizeRows         *bool                      `json:"legendColorizeRows,omitempty"`
 	LegendOpacity              *float32                   `json:"legendOpacity,omitempty"`
 	LegendOrientationThreshold *int                       `json:"legendOrientationThreshold,omitempty"`
 	Note                       string                     `json:"note"`
@@ -2844,11 +3052,17 @@ type ScatterViewProperties struct {
 	XDomain           []float32                 `json:"xDomain"`
 	XPrefix           string                    `json:"xPrefix"`
 	XSuffix           string                    `json:"xSuffix"`
+	XTickStart        *float32                  `json:"xTickStart,omitempty"`
+	XTickStep         *float32                  `json:"xTickStep,omitempty"`
+	XTotalTicks       *int                      `json:"xTotalTicks,omitempty"`
 	YAxisLabel        string                    `json:"yAxisLabel"`
 	YColumn           string                    `json:"yColumn"`
 	YDomain           []float32                 `json:"yDomain"`
 	YPrefix           string                    `json:"yPrefix"`
 	YSuffix           string                    `json:"ySuffix"`
+	YTickStart        *float32                  `json:"yTickStart,omitempty"`
+	YTickStep         *float32                  `json:"yTickStep,omitempty"`
+	YTotalTicks       *int                      `json:"yTotalTicks,omitempty"`
 }
 
 // ScatterViewPropertiesShape defines model for ScatterViewProperties.Shape.
@@ -2859,6 +3073,9 @@ type ScatterViewPropertiesType string
 
 // ScraperTargetRequest defines model for ScraperTargetRequest.
 type ScraperTargetRequest struct {
+
+	// Skip TLS verification on endpoint.
+	AllowInsecure *bool `json:"allowInsecure,omitempty"`
 
 	// The ID of the bucket to write to.
 	BucketID *string `json:"bucketID,omitempty"`
@@ -2946,13 +3163,11 @@ type SingleStatViewProperties struct {
 	DecimalPlaces DecimalPlaces `json:"decimalPlaces"`
 
 	// Legend define encoding of data into a view's legend
-	Legend                     Legend                        `json:"legend"`
-	LegendOpacity              *float32                      `json:"legendOpacity,omitempty"`
-	LegendOrientationThreshold *int                          `json:"legendOrientationThreshold,omitempty"`
-	Note                       string                        `json:"note"`
-	Prefix                     string                        `json:"prefix"`
-	Queries                    []DashboardQuery              `json:"queries"`
-	Shape                      SingleStatViewPropertiesShape `json:"shape"`
+	Legend  Legend                        `json:"legend"`
+	Note    string                        `json:"note"`
+	Prefix  string                        `json:"prefix"`
+	Queries []DashboardQuery              `json:"queries"`
+	Shape   SingleStatViewPropertiesShape `json:"shape"`
 
 	// If true, will display note when empty
 	ShowNoteWhenEmpty bool                         `json:"showNoteWhenEmpty"`
@@ -3427,8 +3642,8 @@ type TemplateEnvReferences []struct {
 	Value *interface{} `json:"value"`
 }
 
-// TemplateExport defines model for TemplateExport.
-type TemplateExport struct {
+// TemplateExportByID defines model for TemplateExportByID.
+type TemplateExportByID struct {
 	OrgIDs *[]struct {
 		OrgID           *string `json:"orgID,omitempty"`
 		ResourceFilters *struct {
@@ -3439,7 +3654,25 @@ type TemplateExport struct {
 	Resources *struct {
 		Id   string       `json:"id"`
 		Kind TemplateKind `json:"kind"`
-		Name *string      `json:"name,omitempty"`
+
+		// if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported
+		Name *string `json:"name,omitempty"`
+	} `json:"resources,omitempty"`
+	StackID *string `json:"stackID,omitempty"`
+}
+
+// TemplateExportByName defines model for TemplateExportByName.
+type TemplateExportByName struct {
+	OrgIDs *[]struct {
+		OrgID           *string `json:"orgID,omitempty"`
+		ResourceFilters *struct {
+			ByLabel        *[]string       `json:"byLabel,omitempty"`
+			ByResourceKind *[]TemplateKind `json:"byResourceKind,omitempty"`
+		} `json:"resourceFilters,omitempty"`
+	} `json:"orgIDs,omitempty"`
+	Resources *struct {
+		Kind TemplateKind `json:"kind"`
+		Name string       `json:"name"`
 	} `json:"resources,omitempty"`
 	StackID *string `json:"stackID,omitempty"`
 }
@@ -3913,12 +4146,15 @@ type XYViewProperties struct {
 	Axes Axes `json:"axes"`
 
 	// Colors define color encoding of data into a visualization
-	Colors         []DashboardColor                `json:"colors"`
-	Geom           XYGeom                          `json:"geom"`
-	HoverDimension *XYViewPropertiesHoverDimension `json:"hoverDimension,omitempty"`
+	Colors             []DashboardColor                `json:"colors"`
+	GenerateXAxisTicks *[]string                       `json:"generateXAxisTicks,omitempty"`
+	GenerateYAxisTicks *[]string                       `json:"generateYAxisTicks,omitempty"`
+	Geom               XYGeom                          `json:"geom"`
+	HoverDimension     *XYViewPropertiesHoverDimension `json:"hoverDimension,omitempty"`
 
 	// Legend define encoding of data into a view's legend
 	Legend                     Legend                   `json:"legend"`
+	LegendColorizeRows         *bool                    `json:"legendColorizeRows,omitempty"`
 	LegendOpacity              *float32                 `json:"legendOpacity,omitempty"`
 	LegendOrientationThreshold *int                     `json:"legendOrientationThreshold,omitempty"`
 	Note                       string                   `json:"note"`
@@ -3932,7 +4168,13 @@ type XYViewProperties struct {
 	TimeFormat        *string              `json:"timeFormat,omitempty"`
 	Type              XYViewPropertiesType `json:"type"`
 	XColumn           *string              `json:"xColumn,omitempty"`
+	XTickStart        *float32             `json:"xTickStart,omitempty"`
+	XTickStep         *float32             `json:"xTickStep,omitempty"`
+	XTotalTicks       *int                 `json:"xTotalTicks,omitempty"`
 	YColumn           *string              `json:"yColumn,omitempty"`
+	YTickStart        *float32             `json:"yTickStart,omitempty"`
+	YTickStep         *float32             `json:"yTickStep,omitempty"`
+	YTotalTicks       *int                 `json:"yTotalTicks,omitempty"`
 }
 
 // XYViewPropertiesHoverDimension defines model for XYViewProperties.HoverDimension.
@@ -5624,7 +5866,7 @@ type DeleteTelegrafsIDOwnersIDParams struct {
 type ApplyTemplateJSONBody TemplateApply
 
 // ExportTemplateJSONBody defines parameters for ExportTemplate.
-type ExportTemplateJSONBody TemplateExport
+type ExportTemplateJSONBody interface{}
 
 // GetUsersParams defines parameters for GetUsers.
 type GetUsersParams struct {


### PR DESCRIPTION
## Proposed Changes

Types and API client is generated from the latest InfluxDB swagger.

Most notable changes:
 -  Setup (onboarding) now sends correctly retentionDuration, if specified. 
 - `RetentionRule` used in `Bucket` now contains `ShardGroupDurationSeconds` to specify shard group duration (available in the next InfluxDB 2 release, not in current v2.0.4)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

