### PR TITLE
expose the Doer to consumers/users

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,6 +94,13 @@ func NewClient(serverURL string, authToken string) Client {
 	return NewClientWithOptions(serverURL, authToken, DefaultOptions())
 }
 
+// NewClientWithDoer creates a Client for connecting to the InfluxDB server using the provided Doer interface.
+// authToken is an authentication token. It can be empty in case of connecting to newly installed InfluxDB server, which has not been set up yet.
+func NewClientWithDoer(doer http.Doer, serverURL, authToken string, options *Options) Client {
+	options.httpOptions.SetHTTPDoer(doer)
+	return NewClientWithOptions(serverURL, authToken, options)
+}
+
 // NewClientWithOptions creates Client for connecting to given serverURL with provided authentication token
 // and configured with custom Options.
 // serverURL is the InfluxDB server base URL, e.g. http://localhost:8086,

--- a/examples_test.go
+++ b/examples_test.go
@@ -44,7 +44,7 @@ func ExampleClient_newClientWithDoer() {
 
 	// Create a new client using an InfluxDB server base URL and an authentication token
 	// Create client and set batch size to 20
-	client := influxdb2.NewClientWithDoer(sampleDoer, "my-token", influxdb2.DefaultOptions().SetBatchSize(20))
+	client := influxdb2.NewClientWithDoer(sampleDoer, "http://no-ssl-influx", "my-token", influxdb2.DefaultOptions().SetBatchSize(20))
 
 	// Always close client at the end
 	defer client.Close()

--- a/examples_test.go
+++ b/examples_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 
+	gohttp "net/http"
+
 	"github.com/influxdata/influxdb-client-go/v2"
 	"github.com/influxdata/influxdb-client-go/v2/domain"
 )
@@ -25,6 +27,24 @@ func ExampleClient_newClientWithOptions() {
 	// Create client and set batch size to 20
 	client := influxdb2.NewClientWithOptions("http://localhost:8086", "my-token",
 		influxdb2.DefaultOptions().SetBatchSize(20))
+
+	// Always close client at the end
+	defer client.Close()
+}
+
+type SampleDoer struct {
+	httpClient *gohttp.Client
+}
+func(doer *SampleDoer) Do(httpReq *gohttp.Request) (*gohttp.Response, error){
+	return doer.Do(httpReq)
+}
+func ExampleClient_newClientWithDoer() {
+	//create a new "Doer" - in this case it is a simple struct which implements "Do"
+	sampleDoer := &SampleDoer{} //
+
+	// Create a new client using an InfluxDB server base URL and an authentication token
+	// Create client and set batch size to 20
+	client := influxdb2.NewClientWithDoer(sampleDoer, "my-token", influxdb2.DefaultOptions().SetBatchSize(20))
 
 	// Always close client at the end
 	defer client.Close()

--- a/options.go
+++ b/options.go
@@ -139,6 +139,16 @@ func (o *Options) HTTPClient() *nethttp.Client {
 	return o.httpOptions.HTTPClient()
 }
 
+// SetHTTPDoer will configure the http.Client that is used
+// for HTTP requests. If set to nil, this has no effect.
+//
+// Setting the HTTPDoer will cause the other HTTP options
+// to be ignored.
+func (o *Options) SetHTTPDoer(d http.Doer) *Options {
+	o.httpOptions.SetHTTPDoer(d)
+	return o
+}
+
 // SetHTTPClient will configure the http.Client that is used
 // for HTTP requests. If set to nil, an HTTPClient will be
 // generated.


### PR DESCRIPTION
## Proposed Changes

these changes will allow a consumer to set the "Doer", allowing someone to establish the httpClient transport outside of the influx db client. the openziti project is a zero-trust sdk which allows for replacing the network connection with a more secure overlay network. To do that we need to be able to create "the socket/pipe" between the client and the server. Golang has wonderful abstractions for this already in `http.Client` (the Transport property). We are leveraging that property. I didn't find a clean way in the existing API to access/replace the httpClient's Transport but I did discover that api.http.service.go already had Doer exposed - so I figured that was the pattern that would be acceptable.

I'm open to changing it however you would like or need though?

## Checklist

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate (doesn't seem appropriate?)
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [?] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
☝️ this returned an empty response - I would have signed it if I could have