### PR TITLE
fix: added mutex lock and unlock around read to logger struct for con…

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -74,42 +74,58 @@ func (l *logger) SetPrefix(prefix string) {
 }
 
 func (l *logger) Debugf(format string, v ...interface{}) {
+	l.lock.Lock()
 	if l.logLevel >= DebugLevel {
 		log.Print(l.prefix, " D! ", fmt.Sprintf(format, v...))
 	}
+	l.lock.Unlock()
 }
 func (l *logger) Debug(msg string) {
+	l.lock.Lock()
 	if l.logLevel >= DebugLevel {
 		log.Print(l.prefix, " D! ", msg)
 	}
+	l.lock.Unlock()
 }
 
 func (l *logger) Infof(format string, v ...interface{}) {
+	l.lock.Lock()
 	if l.logLevel >= InfoLevel {
 		log.Print(l.prefix, " I! ", fmt.Sprintf(format, v...))
 	}
+	l.lock.Unlock()
 }
 func (l *logger) Info(msg string) {
+	l.lock.Lock()
 	if l.logLevel >= DebugLevel {
 		log.Print(l.prefix, " I! ", msg)
 	}
+	l.lock.Unlock()
 }
 
 func (l *logger) Warnf(format string, v ...interface{}) {
+	l.lock.Lock()
 	if l.logLevel >= WarningLevel {
 		log.Print(l.prefix, " W! ", fmt.Sprintf(format, v...))
 	}
+	l.lock.Unlock()
 }
 func (l *logger) Warn(msg string) {
+	l.lock.Lock()
 	if l.logLevel >= WarningLevel {
 		log.Print(l.prefix, " W! ", msg)
 	}
+	l.lock.Unlock()
 }
 
 func (l *logger) Errorf(format string, v ...interface{}) {
+	l.lock.Lock()
 	log.Print(l.prefix, " E! ", fmt.Sprintf(format, v...))
+	l.lock.Unlock()
 }
 
 func (l *logger) Error(msg string) {
+	l.lock.Lock()
 	log.Print(l.prefix, " [E]! ", msg)
+	l.lock.Unlock()
 }


### PR DESCRIPTION
…current use

Closes #

## Proposed Changes

Mutex lock for reading to logger struct for concurrent clients. Race conditions occur if one client uses the Info function and the other client sets the log level.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
