### PR TITLE
chore(ci): switch to next-gen CircleCI's convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.15.6-buster
+      - image: cimg/go:1.15.6
         environment:
           ENV: CI
           GO111MODULE: "on"


### PR DESCRIPTION
## Proposed Changes

The current images are deprecated and no longer supported:

- https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034?mkt_tok=NDg1LVpNSC02MjYAAAF_aZ4aQBMMtwIJatxoGz4de_IMPoNZJOUAhbHY2j7KD_4fR38oMpf0qFjUBd15_QNaVKiHbjM5WE0emhPAvcNcagGm1rnILLJptARAtBWPhtQ
- https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
