### PR TITLE
feat: server state check functions improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## Unreleased
 ### Features
-- [#285](https://github.com/influxdata/influxdb-client-go/pull/285) Added *Client.Ping()* function which returns status where server is available. This the only validation method available for both OSS and Cloud.
+- [#285](https://github.com/influxdata/influxdb-client-go/pull/285) Added *Client.Ping()* function as the only validation method available in both OSS and Cloud.
 
 ### Bug fixes
-- [#285](https://github.com/influxdata/influxdb-client-go/pull/285) Functions *Client.Health()* and *Client.Ready()* correctly reports error when calling them against InfluxDB Cloud, where those endpoints are not available.
+- [#285](https://github.com/influxdata/influxdb-client-go/pull/285) Functions *Client.Health()* and *Client.Ready()* correctly report an error when called against InfluxDB Cloud.
 
 ### Breaking change
-- [#285](https://github.com/influxdata/influxdb-client-go/pull/285) Functions *Client.Ready()* now returns full uptime info as returned by server.
+- [#285](https://github.com/influxdata/influxdb-client-go/pull/285) Function *Client.Ready()* now returns `*domain.Ready` with full uptime info.
  
 
 ## 2.5.1[2021-09-17]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
-## unreleased
-### Bug fixes
-
+## Unreleased
 ### Features
+- [#285](https://github.com/influxdata/influxdb-client-go/pull/285) Added *Client.Ping()* function which returns status where server is available. This the only validation method available for both OSS and Cloud.
+
+### Bug fixes
+- [#285](https://github.com/influxdata/influxdb-client-go/pull/285) Functions *Client.Health()* and *Client.Ready()* correctly reports error when calling them against InfluxDB Cloud, where those endpoints are not available.
+
+### Breaking change
+- [#285](https://github.com/influxdata/influxdb-client-go/pull/285) Functions *Client.Ready()* now returns full uptime info as returned by server.
+ 
 
 ## 2.5.1[2021-09-17]
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains the reference Go client for InfluxDB 2.
     - [Queries in Detail](#queries)
     - [Concurrency](#concurrency)
     - [Proxy and redirects](#proxy-and-redirects)
+    - [Checking Server State](#checking-server-state)
 - [InfluxDB 1.8 API compatibility](#influxdb-18-api-compatibility)
 - [Contributing](#contributing)
 - [License](#license)
@@ -530,6 +531,17 @@ httpClient := &http.Client{
 }
 client := influxdb2.NewClientWithOptions("http://localhost:8086", token, influxdb2.DefaultOptions().SetHTTPClient(httpClient))
 ``` 
+
+### Checking Server State
+There are three functions for checking server is up and ready for communication:
+
+| Function| Description | Availability |
+|:----------|:----------|:----------|
+| [Health()](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2#Client.Health) | Detailed info about the server status, along with version string | OSS |
+| [Ready()](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2#Client.Ready) | Server uptime info | OSS |
+| [Ping()](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2#Client.Ping) | Whether a server is up | OSS, Cloud |
+
+Only the [Ping()](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2#Client.Ping) function is able to return status of an Influx DB Cloud server.
 
 ## InfluxDB 1.8 API compatibility
   

--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ client := influxdb2.NewClientWithOptions("http://localhost:8086", token, influxd
 ``` 
 
 ### Checking Server State
-There are three functions for checking server is up and ready for communication:
+There are three functions for checking whether a server is up and ready for communication:
 
 | Function| Description | Availability |
 |:----------|:----------|:----------|
@@ -541,7 +541,7 @@ There are three functions for checking server is up and ready for communication:
 | [Ready()](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2#Client.Ready) | Server uptime info | OSS |
 | [Ping()](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2#Client.Ping) | Whether a server is up | OSS, Cloud |
 
-Only the [Ping()](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2#Client.Ping) function is able to return status of an Influx DB Cloud server.
+Only the [Ping()](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2#Client.Ping) function works in InfluxDB Cloud server.
 
 ## InfluxDB 1.8 API compatibility
   

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -108,28 +108,28 @@ func TestQueryCVSResultSingleTable(t *testing.T) {
 func TestQueryCVSResultMultiTables(t *testing.T) {
 	csvTable := `#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
 #group,false,false,true,true,false,false,true,true,true,true
-#default,_result,,,,,,,,,
+#default,_result1,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,a,b
 ,,0,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T10:34:08.135814545Z,1.4,f,test,1,adsfasdf
 ,,0,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T22:08:44.850214724Z,6.6,f,test,1,adsfasdf
 
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string
 #group,false,false,true,true,false,false,true,true,true,true
-#default,_result,,,,,,,,,
+#default,_result2,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,a,b
 ,,1,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T10:34:08.135814545Z,4,i,test,1,adsfasdf
 ,,1,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T22:08:44.850214724Z,-1,i,test,1,adsfasdf
 
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,boolean,string,string,string,string
 #group,false,false,true,true,false,false,true,true,true,true
-#default,_result,,,,,,,,,
+#default,_result3,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,a,b
 ,,2,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T22:08:44.62797864Z,false,f,test,0,adsfasdf
 ,,2,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T22:08:44.969100374Z,true,f,test,0,adsfasdf
 
 #datatype,string,long,dateTime:RFC3339Nano,dateTime:RFC3339Nano,dateTime:RFC3339Nano,unsignedLong,string,string,string,string
 #group,false,false,true,true,false,false,true,true,true,true
-#default,_result,,,,,,,,,
+#default,_result4,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,a,b
 ,,3,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T22:08:44.62797864Z,0,i,test,0,adsfasdf
 ,,3,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T22:08:44.969100374Z,2,i,test,0,adsfasdf
@@ -137,7 +137,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 `
 	expectedTable1 := query.NewFluxTableMetadataFull(0,
 		[]*query.FluxColumn{
-			query.NewFluxColumnFull("string", "_result", "result", false, 0),
+			query.NewFluxColumnFull("string", "_result1", "result", false, 0),
 			query.NewFluxColumnFull("long", "", "table", false, 1),
 			query.NewFluxColumnFull("dateTime:RFC3339", "", "_start", true, 2),
 			query.NewFluxColumnFull("dateTime:RFC3339", "", "_stop", true, 3),
@@ -151,7 +151,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 	)
 	expectedRecord11 := query.NewFluxRecord(0,
 		map[string]interface{}{
-			"result":       "_result",
+			"result":       "_result1",
 			"table":        int64(0),
 			"_start":       mustParseTime("2020-02-17T22:19:49.747562847Z"),
 			"_stop":        mustParseTime("2020-02-18T22:19:49.747562847Z"),
@@ -165,7 +165,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 	)
 	expectedRecord12 := query.NewFluxRecord(0,
 		map[string]interface{}{
-			"result":       "_result",
+			"result":       "_result1",
 			"table":        int64(0),
 			"_start":       mustParseTime("2020-02-17T22:19:49.747562847Z"),
 			"_stop":        mustParseTime("2020-02-18T22:19:49.747562847Z"),
@@ -180,7 +180,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 
 	expectedTable2 := query.NewFluxTableMetadataFull(1,
 		[]*query.FluxColumn{
-			query.NewFluxColumnFull("string", "_result", "result", false, 0),
+			query.NewFluxColumnFull("string", "_result2", "result", false, 0),
 			query.NewFluxColumnFull("long", "", "table", false, 1),
 			query.NewFluxColumnFull("dateTime:RFC3339", "", "_start", true, 2),
 			query.NewFluxColumnFull("dateTime:RFC3339", "", "_stop", true, 3),
@@ -194,7 +194,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 	)
 	expectedRecord21 := query.NewFluxRecord(1,
 		map[string]interface{}{
-			"result":       "_result",
+			"result":       "_result2",
 			"table":        int64(1),
 			"_start":       mustParseTime("2020-02-17T22:19:49.747562847Z"),
 			"_stop":        mustParseTime("2020-02-18T22:19:49.747562847Z"),
@@ -208,7 +208,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 	)
 	expectedRecord22 := query.NewFluxRecord(1,
 		map[string]interface{}{
-			"result":       "_result",
+			"result":       "_result2",
 			"table":        int64(1),
 			"_start":       mustParseTime("2020-02-17T22:19:49.747562847Z"),
 			"_stop":        mustParseTime("2020-02-18T22:19:49.747562847Z"),
@@ -223,7 +223,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 
 	expectedTable3 := query.NewFluxTableMetadataFull(2,
 		[]*query.FluxColumn{
-			query.NewFluxColumnFull("string", "_result", "result", false, 0),
+			query.NewFluxColumnFull("string", "_result3", "result", false, 0),
 			query.NewFluxColumnFull("long", "", "table", false, 1),
 			query.NewFluxColumnFull("dateTime:RFC3339", "", "_start", true, 2),
 			query.NewFluxColumnFull("dateTime:RFC3339", "", "_stop", true, 3),
@@ -237,7 +237,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 	)
 	expectedRecord31 := query.NewFluxRecord(2,
 		map[string]interface{}{
-			"result":       "_result",
+			"result":       "_result3",
 			"table":        int64(2),
 			"_start":       mustParseTime("2020-02-17T22:19:49.747562847Z"),
 			"_stop":        mustParseTime("2020-02-18T22:19:49.747562847Z"),
@@ -251,7 +251,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 	)
 	expectedRecord32 := query.NewFluxRecord(2,
 		map[string]interface{}{
-			"result":       "_result",
+			"result":       "_result3",
 			"table":        int64(2),
 			"_start":       mustParseTime("2020-02-17T22:19:49.747562847Z"),
 			"_stop":        mustParseTime("2020-02-18T22:19:49.747562847Z"),
@@ -266,7 +266,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 
 	expectedTable4 := query.NewFluxTableMetadataFull(3,
 		[]*query.FluxColumn{
-			query.NewFluxColumnFull("string", "_result", "result", false, 0),
+			query.NewFluxColumnFull("string", "_result4", "result", false, 0),
 			query.NewFluxColumnFull("long", "", "table", false, 1),
 			query.NewFluxColumnFull("dateTime:RFC3339Nano", "", "_start", true, 2),
 			query.NewFluxColumnFull("dateTime:RFC3339Nano", "", "_stop", true, 3),
@@ -280,7 +280,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 	)
 	expectedRecord41 := query.NewFluxRecord(3,
 		map[string]interface{}{
-			"result":       "_result",
+			"result":       "_result4",
 			"table":        int64(3),
 			"_start":       mustParseTime("2020-02-17T22:19:49.747562847Z"),
 			"_stop":        mustParseTime("2020-02-18T22:19:49.747562847Z"),
@@ -294,7 +294,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 	)
 	expectedRecord42 := query.NewFluxRecord(3,
 		map[string]interface{}{
-			"result":       "_result",
+			"result":       "_result4",
 			"table":        int64(3),
 			"_start":       mustParseTime("2020-02-17T22:19:49.747562847Z"),
 			"_stop":        mustParseTime("2020-02-18T22:19:49.747562847Z"),
@@ -382,6 +382,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 	require.Equal(t, queryResult.table, expectedTable4)
 	require.NotNil(t, queryResult.Record())
 	require.Equal(t, queryResult.Record(), expectedRecord42)
+	assert.Equal(t, "_result4", queryResult.Record().ValueByKey("result"))
 
 	require.False(t, queryResult.Next())
 	require.Nil(t, queryResult.Err())
@@ -474,7 +475,7 @@ func TestQueryRawResult(t *testing.T) {
 		``,
 		`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string`,
 		`#group,false,false,true,true,false,false,true,true,true,true`,
-		`#default,_result,,,,,,,,,`,
+		`#default,_result2,,,,,,,,,`,
 		`,result,table,_start,_stop,_time,_value,_field,_measurement,a,b`,
 		`,,1,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T10:34:08.135814545Z,4,i,test,1,adsfasdf`,
 		`,,1,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T22:08:44.850214724Z,1,i,test,1,adsfasdf`,

--- a/api/write_test.go
+++ b/api/write_test.go
@@ -95,15 +95,6 @@ func TestFlushInterval(t *testing.T) {
 	writeAPI.Close()
 
 	service.Close()
-	writeAPI = NewWriteAPI("my-org", "my-bucket", service, writeAPI.writeOptions.SetFlushInterval(500))
-	for _, p := range points {
-		writeAPI.WritePoint(p)
-	}
-	require.Len(t, service.Lines(), 0)
-	<-time.After(time.Millisecond * 550)
-	require.Len(t, service.Lines(), 5)
-
-	writeAPI.Close()
 }
 
 func TestRetry(t *testing.T) {

--- a/api/write_test.go
+++ b/api/write_test.go
@@ -84,23 +84,23 @@ func TestGzipWithFlushing(t *testing.T) {
 }
 func TestFlushInterval(t *testing.T) {
 	service := test.NewTestService(t, "http://localhost:8888")
-	writeAPI := NewWriteAPI("my-org", "my-bucket", service, write.DefaultOptions().SetBatchSize(10).SetFlushInterval(10))
+	writeAPI := NewWriteAPI("my-org", "my-bucket", service, write.DefaultOptions().SetBatchSize(10).SetFlushInterval(30))
 	points := test.GenPoints(5)
 	for _, p := range points {
 		writeAPI.WritePoint(p)
 	}
 	require.Len(t, service.Lines(), 0)
-	<-time.After(time.Millisecond * 15)
+	<-time.After(time.Millisecond * 50)
 	require.Len(t, service.Lines(), 5)
 	writeAPI.Close()
 
 	service.Close()
-	writeAPI = NewWriteAPI("my-org", "my-bucket", service, writeAPI.writeOptions.SetFlushInterval(50))
+	writeAPI = NewWriteAPI("my-org", "my-bucket", service, writeAPI.writeOptions.SetFlushInterval(500))
 	for _, p := range points {
 		writeAPI.WritePoint(p)
 	}
 	require.Len(t, service.Lines(), 0)
-	<-time.After(time.Millisecond * 60)
+	<-time.After(time.Millisecond * 550)
 	require.Len(t, service.Lines(), 5)
 
 	writeAPI.Close()

--- a/client.go
+++ b/client.go
@@ -34,7 +34,7 @@ type Client interface {
 	// Health returns an InfluxDB server health check result. Read the HealthCheck.Status field to get server status.
 	// Health doesn't validate authentication params.
 	Health(ctx context.Context) (*domain.HealthCheck, error)
-	// Ping validates InfluxDB server is running. It doesn't validate authentication params.
+	// Ping validates whether InfluxDB server is running. It doesn't validate authentication params.
 	Ping(ctx context.Context) (bool, error)
 	// Close ensures all ongoing asynchronous write clients finish.
 	// Also closes all idle connections, in case of HTTP client was created internally.

--- a/client_e2e_test.go
+++ b/client_e2e_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 // Copyright 2020-2021 InfluxData, Inc. All rights reserved.
@@ -63,13 +64,14 @@ func TestSetup(t *testing.T) {
 func TestReady(t *testing.T) {
 	client := influxdb2.NewClient(serverURL, "")
 
-	ok, err := client.Ready(context.Background())
-	if err != nil {
-		t.Error(err)
-	}
-	if !ok {
-		t.Fail()
-	}
+	ready, err := client.Ready(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, ready)
+	require.NotNil(t, ready.Started)
+	assert.True(t, ready.Started.Before(time.Now()))
+	dur, err := time.ParseDuration(*ready.Up)
+	require.NoError(t, err)
+	assert.True(t, dur.Seconds() > 0)
 }
 
 func TestHealth(t *testing.T) {
@@ -81,6 +83,14 @@ func TestHealth(t *testing.T) {
 	}
 	require.NotNil(t, health)
 	assert.Equal(t, domain.HealthCheckStatusPass, health.Status)
+}
+
+func TestPing(t *testing.T) {
+	client := influxdb2.NewClient(serverURL, "")
+
+	ok, err := client.Ping(context.Background())
+	require.NoError(t, err)
+	assert.True(t, ok)
 }
 
 func TestWrite(t *testing.T) {
@@ -159,6 +169,14 @@ func TestQuery(t *testing.T) {
 		}
 	}
 
+}
+
+func TestPingV1(t *testing.T) {
+	client := influxdb2.NewClient(serverV1URL, "")
+
+	ok, err := client.Ping(context.Background())
+	require.NoError(t, err)
+	assert.True(t, ok)
 }
 
 func TestHealthV1Compatibility(t *testing.T) {

--- a/internal/write/service_test.go
+++ b/internal/write/service_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	ilog "log"
 	"strings"
 	"sync"
 	"testing"
@@ -132,6 +133,7 @@ func TestRetryStrategy(t *testing.T) {
 
 func TestBufferOverwrite(t *testing.T) {
 	log.Log.SetLogLevel(log.DebugLevel)
+	ilog.SetFlags(ilog.Ldate | ilog.Lmicroseconds)
 	hs := test.NewTestService(t, "http://localhost:8086")
 	// Buffer limit 15000, bach is 5000 => buffer for 3 batches
 	opts := write.DefaultOptions().SetRetryInterval(1).SetRetryBufferLimit(15000)
@@ -165,7 +167,6 @@ func TestBufferOverwrite(t *testing.T) {
 	assert.Equal(t, 3, srv.retryQueue.list.Len())
 
 	// Write early and overwrite
-	<-time.After(time.Millisecond)
 	b4 := NewBatch("4\n", opts.RetryInterval(), opts.MaxRetryTime())
 	// No write will occur, because retry delay has not passed yet
 	// However new bach will be added to retry queue. Retry queue has limit 3,


### PR DESCRIPTION
Closes #284 

## Proposed Changes

Improving server state functions:
 - added Ping() - the only way how to check Cloud server state (**Client interface breaking change**)
 - Health() and Ready() fails when connecting to Cloud
 - Ready() returns server uptime info, instead of bool (**Compatibility Breaking Change** )

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

