### PR TITLE
feat: adding FluxRecord.Result() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Features
 - [#285](https://github.com/influxdata/influxdb-client-go/pull/285) Added *Client.Ping()* function as the only validation method available in both OSS and Cloud.
+- [#287](https://github.com/influxdata/influxdb-client-go/pull/287) Added *FluxRecord.Result()* function as a convenient way to retrieve the Flux result name of data.
 
 ### Bug fixes
 - [#285](https://github.com/influxdata/influxdb-client-go/pull/285) Functions *Client.Health()* and *Client.Ready()* correctly report an error when called against InfluxDB Cloud.

--- a/api/query/table.go
+++ b/api/query/table.go
@@ -180,6 +180,12 @@ func (r *FluxRecord) Field() string {
 	return stringValue(r.values, "_field")
 }
 
+// Result returns the value of the _result column, which represents result name.
+// Returns empty string if there is no column "result".
+func (r *FluxRecord) Result() string {
+	return stringValue(r.values, "result")
+}
+
 // Measurement returns the measurement name of the record
 // Returns empty string if there is no column "_measurement".
 func (r *FluxRecord) Measurement() string {

--- a/api/query/table_test.go
+++ b/api/query/table_test.go
@@ -85,6 +85,7 @@ func TestRecord(t *testing.T) {
 	assert.Equal(t, mustParseTime("2020-02-17T22:19:49.747562847Z"), record.Start())
 	assert.Equal(t, mustParseTime("2020-02-18T22:19:49.747562847Z"), record.Stop())
 	assert.Equal(t, mustParseTime("2020-02-18T10:34:08.135814545Z"), record.Time())
+	assert.Equal(t, "_result", record.Result())
 	assert.Equal(t, "f", record.Field())
 	assert.Equal(t, 1.4, record.Value())
 	assert.Equal(t, "test", record.Measurement())
@@ -92,18 +93,18 @@ func TestRecord(t *testing.T) {
 
 	agRec := &FluxRecord{table: 0,
 		values: map[string]interface{}{
-			"result": "_result",
 			"room":   "bathroom",
 			"sensor": "SHT",
 			"temp":   24.3,
 			"hum":    42,
 		},
 	}
-	require.Len(t, agRec.values, 5)
+	require.Len(t, agRec.values, 4)
 	assert.Equal(t, time.Time{}, agRec.Start())
 	assert.Equal(t, time.Time{}, agRec.Stop())
 	assert.Equal(t, time.Time{}, agRec.Time())
 	assert.Equal(t, "", agRec.Field())
+	assert.Equal(t, "", agRec.Result())
 	assert.Nil(t, agRec.Value())
 	assert.Equal(t, "", agRec.Measurement())
 	assert.Equal(t, 0, agRec.Table())

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -382,7 +382,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 	require.Equal(t, queryResult.table, expectedTable4)
 	require.NotNil(t, queryResult.Record())
 	require.Equal(t, queryResult.Record(), expectedRecord42)
-	assert.Equal(t, "_result4", queryResult.Record().ValueByKey("result"))
+	assert.Equal(t, "_result4", queryResult.Record().Result())
 
 	require.False(t, queryResult.Next())
 	require.Nil(t, queryResult.Err())


### PR DESCRIPTION
Closes #283

## Proposed Changes

Added *FluxRecord.Result()* function as a convenient way to retrieve the Flux result name of data.
The `Result()` function extends collection of already existing accessor functions: `Table(), Start(), Stop(), Time(),  Measurement() and Value()`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

