### PR TITLE
revise WriteAPI.Flush to attempt to send batches in the retry queue

### DIFF
--- a/api/write.go
+++ b/api/write.go
@@ -114,6 +114,7 @@ func (w *WriteAPIImpl) waitForFlushing() {
 	<-w.bufferInfoCh
 	w.writeInfoCh <- writeBuffInfoReq{}
 	<-w.writeInfoCh
+	w.writeCh <- nil
 }
 
 func (w *WriteAPIImpl) bufferProc() {


### PR DESCRIPTION
Closes #289
Closes #290

## Proposed Changes

After completing standard flush operations that move points from the buffer to queued batch, trigger a re-examination of retries rather than waiting for a timeout.

Also incorporates the cleanup patch for #290.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

I'll address these if it appears this is an acceptable solution to the problem described in #289.

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
