### PR TITLE
feat: add blocking API to write a batch of records

### DIFF
--- a/api/writeAPIBlocking.go
+++ b/api/writeAPIBlocking.go
@@ -58,6 +58,8 @@ type WriteAPIBlocking interface {
 	// WritePoint writes without implicit batching. Batch is created from given number of points
 	// Non-blocking alternative is available in the WriteAPI interface
 	WritePoint(ctx context.Context, point ...*write.Point) error
+	// WriteBatch writes line protocol record(s) that have already been aggregated into a string with newline separators into bucket.
+	WriteBatch(ctx context.Context, batch string) error
 }
 
 // writeAPIBlocking implements WriteAPIBlocking interface
@@ -75,6 +77,13 @@ func (w *writeAPIBlocking) write(ctx context.Context, line string) error {
 	err := w.service.WriteBatch(ctx, iwrite.NewBatch(line, w.writeOptions.RetryInterval(), w.writeOptions.MaxRetryTime()))
 	if err != nil {
 		return err.Unwrap()
+	}
+	return nil
+}
+
+func (w *writeAPIBlocking) WriteBatch(ctx context.Context, batch string) error {
+	if len(batch) > 0 {
+		return w.write(ctx, batch)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #295

## Proposed Changes

This extends the blocking API to allow writing line protocol records that have already been combined into a string with newline separators.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
