### PR TITLE
chore: optimize single-record blocking write

### DIFF
--- a/api/writeAPIBlocking.go
+++ b/api/writeAPIBlocking.go
@@ -51,7 +51,8 @@ import (
 //	}
 type WriteAPIBlocking interface {
 	// WriteRecord writes line protocol record(s) into bucket.
-	// WriteRecord writes without implicit batching. Batch is created from given number of records
+	// WriteRecord writes without implicit batching. Batch is created from given number of records.
+	// Individual arguments can also be batches (multiple records separated by newline).
 	// Non-blocking alternative is available in the WriteAPI interface
 	WriteRecord(ctx context.Context, line ...string) error
 	// WritePoint data point into bucket.
@@ -80,18 +81,25 @@ func (w *writeAPIBlocking) write(ctx context.Context, line string) error {
 }
 
 func (w *writeAPIBlocking) WriteRecord(ctx context.Context, line ...string) error {
-	if len(line) > 0 {
-		var sb strings.Builder
-		for _, line := range line {
-			b := []byte(line)
-			b = append(b, 0xa)
-			if _, err := sb.Write(b); err != nil {
-				return err
-			}
-		}
-		return w.write(ctx, sb.String())
+	if len(line) == 0 {
+		return nil
 	}
-	return nil
+	if len(line) == 1 {
+		ln := line[0]
+		if ln[len(ln)-1] != '\n' {
+			ln += "\n"
+		}
+		return w.write(ctx, ln)
+	}
+	var sb strings.Builder
+	for _, line := range line {
+		b := []byte(line)
+		b = append(b, 0xa)
+		if _, err := sb.Write(b); err != nil {
+			return err
+		}
+	}
+	return w.write(ctx, sb.String())
 }
 
 func (w *writeAPIBlocking) WritePoint(ctx context.Context, point ...*write.Point) error {


### PR DESCRIPTION
## Proposed Changes

This optimizes `WriteAPIBlocking.WriteRecord` in the case where a single string is provided, and explicitly documents that batches (records separated/terminated by newline) can be passed.  A test is added to confirm that this works as expected.

Unless the server chokes on empty lines this should resolve the need that motivated #295.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
