### PR TITLE
fix: Close the response body of a WriteBatch call

### DIFF
--- a/internal/write/service.go
+++ b/internal/write/service.go
@@ -246,7 +246,7 @@ func (w *Service) WriteBatch(ctx context.Context, batch *Batch) *http2.Error {
 			req.Header.Set("Content-Encoding", "gzip")
 		}
 	}, func(r *http.Response) error {
-		return nil
+		return r.Body.Close()
 	})
 	return perror
 }


### PR DESCRIPTION
## Proposed Changes

Closes the response body after making a `WriteBatch` call. Failing to close the response body was keeping OpenCensus spans from being exported when using `ochttp.Transport` (see: https://github.com/census-instrumentation/opencensus-go/blob/49838f207d61097fc0ebb8aeef306913388376ca/plugin/ochttp/trace.go#L94)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
