### PR TITLE
fix: FluxRecord.Table() returns value of the table column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## unreleased
 ### Features 
-- [#297](https://github.com/influxdata/influxdb-client-go/pull/297),[#298](https://github.com/influxdata/influxdb-client-go/pull/298) Optimized `WriteRecord` of [WriteAPIBlocking](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2/api#WriteAPIBlocking). 
+- [#297](https://github.com/influxdata/influxdb-client-go/pull/297),[#298](https://github.com/influxdata/influxdb-client-go/pull/298) Optimized `WriteRecord` of [WriteAPIBlocking](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2/api#WriteAPIBlocking). Custom batch can be written by single argument. 
 
 ### Bug fixes
 - [#294](https://github.com/influxdata/influxdb-client-go/pull/294)  `WritePoint` and `WriteRecord` of [WriteAPIBlocking](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2/api#WriteAPIBlocking) returns always full error information.
-
+- [300](https://github.com/influxdata/influxdb-client-go/pull/300) Closing the response body after write batch.
+- [302](https://github.com/influxdata/influxdb-client-go/pull/302) FluxRecord.Table() returns value of the table column.
 
 ## 2.6.0[2021-11-26]
 ### Features

--- a/api/query/table_test.go
+++ b/api/query/table_test.go
@@ -70,7 +70,7 @@ func TestRecord(t *testing.T) {
 	record := &FluxRecord{table: 2,
 		values: map[string]interface{}{
 			"result":       "_result",
-			"_table":       int64(0),
+			"table":        int64(2),
 			"_start":       mustParseTime("2020-02-17T22:19:49.747562847Z"),
 			"_stop":        mustParseTime("2020-02-18T22:19:49.747562847Z"),
 			"_time":        mustParseTime("2020-02-18T10:34:08.135814545Z"),

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -35,8 +35,8 @@ func TestQueryCVSResultSingleTable(t *testing.T) {
 #group,false,false,true,true,false,false,true,true,true,true
 #default,_result,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,a,b
-,,0,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T10:34:08.135814545Z,1.4,f,test,1,adsfasdf
-,,0,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T22:08:44.850214724Z,6.6,f,test,1,adsfasdf
+,,1,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T10:34:08.135814545Z,1.4,f,test,1,adsfasdf
+,,1,2020-02-17T22:19:49.747562847Z,2020-02-18T22:19:49.747562847Z,2020-02-18T22:08:44.850214724Z,6.6,f,test,1,adsfasdf
 
 `
 	expectedTable := query.NewFluxTableMetadataFull(0,
@@ -56,7 +56,7 @@ func TestQueryCVSResultSingleTable(t *testing.T) {
 	expectedRecord1 := query.NewFluxRecord(0,
 		map[string]interface{}{
 			"result":       "_result",
-			"table":        int64(0),
+			"table":        int64(1),
 			"_start":       mustParseTime("2020-02-17T22:19:49.747562847Z"),
 			"_stop":        mustParseTime("2020-02-18T22:19:49.747562847Z"),
 			"_time":        mustParseTime("2020-02-18T10:34:08.135814545Z"),
@@ -71,7 +71,7 @@ func TestQueryCVSResultSingleTable(t *testing.T) {
 	expectedRecord2 := query.NewFluxRecord(0,
 		map[string]interface{}{
 			"result":       "_result",
-			"table":        int64(0),
+			"table":        int64(1),
 			"_start":       mustParseTime("2020-02-17T22:19:49.747562847Z"),
 			"_stop":        mustParseTime("2020-02-18T22:19:49.747562847Z"),
 			"_time":        mustParseTime("2020-02-18T22:08:44.850214724Z"),
@@ -100,6 +100,8 @@ func TestQueryCVSResultSingleTable(t *testing.T) {
 	assert.False(t, queryResult.tableChanged)
 	require.NotNil(t, queryResult.Record())
 	require.Equal(t, queryResult.Record(), expectedRecord2)
+	assert.Equal(t, "_result", queryResult.Record().Result())
+	assert.Equal(t, 1, queryResult.Record().Table())
 
 	require.False(t, queryResult.Next())
 	require.Nil(t, queryResult.Err())
@@ -383,6 +385,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 	require.NotNil(t, queryResult.Record())
 	require.Equal(t, queryResult.Record(), expectedRecord42)
 	assert.Equal(t, "_result4", queryResult.Record().Result())
+	assert.Equal(t, 3, queryResult.Record().Table())
 
 	require.False(t, queryResult.Next())
 	require.Nil(t, queryResult.Err())


### PR DESCRIPTION
Closes #301

## Proposed Changes

- `FluxRecord.Table()` returns value of the `table` column.
- `FluxRecord.String()` returns values sorted  by key.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

