### PR TITLE
chore(ci): use new codecov uploader for reporting code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,9 +47,17 @@ jobs:
           name: "Start InfluxDB service"
           command: ./scripts/influxdb-restart.sh
       - run:
+          name: Collecting coverage reports
           command: |
             go get gotest.tools/gotestsum && gotestsum --junitfile /tmp/test-results/unit-tests.xml -- -race -coverprofile=coverage.txt -covermode=atomic -coverpkg '.,./api/...,./internal/.../,./log/...' -tags e2e ./...
-            bash <(curl -s https://codecov.io/bash)
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x ./codecov
+            ./codecov
             go tool cover -html=coverage.txt -o /tmp/artifacts/coverage.html
       - store_artifacts:
           path: /tmp/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,9 +47,12 @@ jobs:
           name: "Start InfluxDB service"
           command: ./scripts/influxdb-restart.sh
       - run:
-          name: Collecting coverage reports
           command: |
             go get gotest.tools/gotestsum && gotestsum --junitfile /tmp/test-results/unit-tests.xml -- -race -coverprofile=coverage.txt -covermode=atomic -coverpkg '.,./api/...,./internal/.../,./log/...' -tags e2e ./...
+            go tool cover -html=coverage.txt -o /tmp/artifacts/coverage.html
+      - run:
+          name: Collecting coverage reports
+          command: |
             curl -Os https://uploader.codecov.io/latest/linux/codecov
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
@@ -58,7 +61,6 @@ jobs:
             shasum -a 256 -c codecov.SHA256SUM
             chmod +x ./codecov
             ./codecov
-            go tool cover -html=coverage.txt -o /tmp/artifacts/coverage.html
       - store_artifacts:
           path: /tmp/artifacts
       - store_artifacts:


### PR DESCRIPTION
## Proposed Changes

The Codecov Bash Uploader is deprecated - https://docs.codecov.com/docs/about-the-codecov-bash-uploader. We have to switch to new one - https://docs.codecov.com/docs/codecov-uploader.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
