### PR TITLE
feat: add User-Agent header overwrite possibility

### DIFF
--- a/api/http/service.go
+++ b/api/http/service.go
@@ -44,6 +44,10 @@ type Service interface {
 	SetAuthorization(authorization string)
 	// Authorization returns current authorization header value
 	Authorization() string
+	// SetUserAgent sets the User-Agent header value
+	SetUserAgent(authorization string)
+	// UserAgent returns current User-Agent header value
+	UserAgent() string
 	// ServerAPIURL returns URL to InfluxDB2 server API space
 	ServerAPIURL() string
 	// ServerURL returns URL to InfluxDB2 server
@@ -55,6 +59,7 @@ type service struct {
 	serverAPIURL  string
 	serverURL     string
 	authorization string
+	userAgent     string
 	client        Doer
 }
 
@@ -90,6 +95,14 @@ func (s *service) SetAuthorization(authorization string) {
 
 func (s *service) Authorization() string {
 	return s.authorization
+}
+
+func (s *service) SetUserAgent(userAgent string) {
+	s.userAgent = userAgent
+}
+
+func (s *service) UserAgent() string {
+	return s.userAgent
 }
 
 func (s *service) DoPostRequest(ctx context.Context, url string, body io.Reader, requestCallback RequestCallback, responseCallback ResponseCallback) *Error {

--- a/internal/test/http_service.go
+++ b/internal/test/http_service.go
@@ -24,6 +24,7 @@ import (
 type HTTPService struct {
 	serverURL      string
 	authorization  string
+	userAgent      string
 	lines          []string
 	t              *testing.T
 	wasGzip        bool
@@ -55,6 +56,11 @@ func (t *HTTPService) ServerAPIURL() string {
 // Authorization returns current authorization header value
 func (t *HTTPService) Authorization() string {
 	return t.authorization
+}
+
+// UserAgent returns current User-Agent header value
+func (t *HTTPService) UserAgent() string {
+	return t.userAgent
 }
 
 // HTTPClient returns nil for this service
@@ -90,6 +96,11 @@ func (t *HTTPService) ReplyError() *http2.Error {
 
 // SetAuthorization sets authorization string
 func (t *HTTPService) SetAuthorization(_ string) {
+
+}
+
+// SetUserAgent sets userAgent string
+func (t *HTTPService) SetUserAgent(_ string) {
 
 }
 


### PR DESCRIPTION
This is a proposal to add the possibility to overwrite the User-Agent field when we do requests.

Example of use : 

```
	c := client.NewClient( fmt.Sprintf("https://%s:%s", "influx_url", "influx_proxy_port"), "influx_token" )
	// Ensures background processes finishes
	defer c.Close()

	c.HTTPService().SetUserAgent("custom_user_agent")
```