### PR TITLE
feat: add User-Agent header overwrite possibility

### DIFF
--- a/api/http/service.go
+++ b/api/http/service.go
@@ -44,6 +44,10 @@ type Service interface {
 	SetAuthorization(authorization string)
 	// Authorization returns current authorization header value
 	Authorization() string
+	// SetUserAgent sets the User-Agent header value
+	SetUserAgent(authorization string)
+	// UserAgent returns current User-Agent header value
+	UserAgent() string
 	// ServerAPIURL returns URL to InfluxDB2 server API space
 	ServerAPIURL() string
 	// ServerURL returns URL to InfluxDB2 server
@@ -55,6 +59,7 @@ type service struct {
 	serverAPIURL  string
 	serverURL     string
 	authorization string
+	userAgent     string
 	client        Doer
 }
 
@@ -92,6 +97,14 @@ func (s *service) Authorization() string {
 	return s.authorization
 }
 
+func (s *service) SetUserAgent(userAgent string) {
+	s.userAgent = userAgent
+}
+
+func (s *service) UserAgent() string {
+	return s.userAgent
+}
+
 func (s *service) DoPostRequest(ctx context.Context, url string, body io.Reader, requestCallback RequestCallback, responseCallback ResponseCallback) *Error {
 	return s.doHTTPRequestWithURL(ctx, http.MethodPost, url, body, requestCallback, responseCallback)
 }
@@ -127,8 +140,13 @@ func (s *service) DoHTTPRequestWithResponse(req *http.Request, requestCallback R
 	if len(s.authorization) > 0 {
 		req.Header.Set("Authorization", s.authorization)
 	}
+
 	if req.Header.Get("User-Agent") == "" {
-		req.Header.Set("User-Agent", http2.UserAgent)
+		if len(s.userAgent) > 0 {
+			req.Header.Set("User-Agent", s.userAgent)
+		} else {
+			req.Header.Set("User-Agent", http2.UserAgent)
+		}
 	}
 	if requestCallback != nil {
 		requestCallback(req)

--- a/internal/test/http_service.go
+++ b/internal/test/http_service.go
@@ -24,6 +24,7 @@ import (
 type HTTPService struct {
 	serverURL      string
 	authorization  string
+	userAgent      string
 	lines          []string
 	t              *testing.T
 	wasGzip        bool
@@ -55,6 +56,11 @@ func (t *HTTPService) ServerAPIURL() string {
 // Authorization returns current authorization header value
 func (t *HTTPService) Authorization() string {
 	return t.authorization
+}
+
+// UserAgent returns current User-Agent header value
+func (t *HTTPService) UserAgent() string {
+	return t.userAgent
 }
 
 // HTTPClient returns nil for this service
@@ -90,6 +96,11 @@ func (t *HTTPService) ReplyError() *http2.Error {
 
 // SetAuthorization sets authorization string
 func (t *HTTPService) SetAuthorization(_ string) {
+
+}
+
+// SetUserAgent sets userAgent string
+func (t *HTTPService) SetUserAgent(_ string) {
 
 }
 


### PR DESCRIPTION
## Proposed Changes

This is a proposal to add the possibility to overwrite the User-Agent field when we do requests.

Example of use :

```
c := client.NewClient( fmt.Sprintf("https://%s:%s", "influx_url", "influx_proxy_port"), "influx_token" )
// Ensures background processes finishes
defer c.Close()

c.HTTPService().SetUserAgent("custom_user_agent")
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x]  A test has been added if appropriate (doesn't seem appropriate)
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)