### PR TITLE
fix: add concurrency panic protection around Client and WriteAPIImpl Close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.2 [2022-03-26]
+### Bug fixes
+- [#317](https://github.com/influxdata/influxdb-client-go/issues/317) Prevent panic if multiple goroutines close influxdb2 client
+
 ## 2.8.1 [2022-03-21]
 ### Bug fixes
 - [#311](https://github.com/influxdata/influxdb-client-go/pull/311) Correctly unwrapping http.Error from Server API calls


### PR DESCRIPTION
## Proposed Changes

This PR aims to address https://github.com/influxdata/influxdb-client-go/issues/317 . If multiple goroutines call `influxdb2.Client.Close()`, or `api.WriteAPI.Close()`, it is possible for there to be a panic due to closing a closed channel.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [ ] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [X] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
