### PR TITLE
feat: added SetupWithToken() method, allowing users to specify Admin token …

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,6 +29,10 @@ type Client interface {
 	// and returns details about newly created entities along with the authorization object.
 	// Retention period of zero will result to infinite retention.
 	Setup(ctx context.Context, username, password, org, bucket string, retentionPeriodHours int) (*domain.OnboardingResponse, error)
+	// SetupWithToken sends request to initialise new InfluxDB server with user, org and bucket, data retention period and token
+	// and returns details about newly created entities along with the authorization object.
+	// Retention period of zero will result to infinite retention.
+	SetupWithToken(ctx context.Context, username, password, org, bucket string, retentionPeriodHours int, token string) (*domain.OnboardingResponse, error)
 	// Ready returns InfluxDB uptime info of server. It doesn't validate authentication params.
 	Ready(ctx context.Context) (*domain.Ready, error)
 	// Health returns an InfluxDB server health check result. Read the HealthCheck.Status field to get server status.
@@ -161,6 +165,10 @@ func (c *clientImpl) Ready(ctx context.Context) (*domain.Ready, error) {
 }
 
 func (c *clientImpl) Setup(ctx context.Context, username, password, org, bucket string, retentionPeriodHours int) (*domain.OnboardingResponse, error) {
+	return c.SetupWithToken(ctx, username, password, org, bucket, retentionPeriodHours, "")
+}
+
+func (c *clientImpl) SetupWithToken(ctx context.Context, username, password, org, bucket string, retentionPeriodHours int, token string) (*domain.OnboardingResponse, error) {
 	if username == "" || password == "" {
 		return nil, errors.New("a username and a password is required for a setup")
 	}
@@ -176,6 +184,7 @@ func (c *clientImpl) Setup(ctx context.Context, username, password, org, bucket 
 		RetentionPeriodSeconds: &retentionPeriodSeconds,
 		RetentionPeriodHrs:     &retentionPeriodHrs,
 		Username:               username,
+		Token:                  &token,
 	}
 	response, err := c.apiClient.PostSetupWithResponse(ctx, params, *body)
 	if err != nil {


### PR DESCRIPTION
added SetupWithToken() method, allowing users to specify Admin token during initialization.

Closes #327

## Proposed Changes

Add `SetupWithToken()` method, clone of `Setup()` method with additional token parameter. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
