### PR TITLE
fix(test): use higher timeouts on Windows

### DIFF
--- a/internal/write/service.go
+++ b/internal/write/service.go
@@ -89,7 +89,7 @@ func NewService(org string, bucket string, httpService http2.Service, options *w
 		writeOptions:         options,
 		retryQueue:           newQueue(int(retryBufferLimit)),
 		retryExponentialBase: 2,
-		retryDelay:           0,
+		retryDelay:           options.RetryInterval(),
 		retryAttempts:        0,
 	}
 }
@@ -196,7 +196,7 @@ func (w *Service) HandleWrite(ctx context.Context, batch *Batch) error {
 			}
 
 			w.retryDelay = w.writeOptions.RetryInterval()
-			w.retryDelay = 0
+			w.retryAttempts = 0
 			if retrying && !batchToWrite.Evicted {
 				w.retryQueue.pop()
 			}


### PR DESCRIPTION
## Proposed Changes

Fixes write and retry tests on Windows

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] Rebased/mergeable
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
