### PR TITLE
fix: logging messages about discarding batch as error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Bug fixes
+- [#341](https://github.com/influxdata/influxdb-client-go/issues/341) Changing logging level of messages about discarding batch to Error. 
+
 ## 2.9.1 [2022-06-24]
 ### Bug fixes
 - [#332](https://github.com/influxdata/influxdb-client-go/issues/332) Retry strategy drops expired batches as soon as they expire.


### PR DESCRIPTION
## Proposed Changes

Changing logging level of messages about discarding batch to Error. A part of the fix for #340

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [ ] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
