### PR TITLE
fix: WriteAPI.Flush() also flushes retry queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [unreleased]
 ### Bug fixes
 - [#341](https://github.com/influxdata/influxdb-client-go/issues/341) Changing logging level of messages about discarding batch to Error. 
+- [#344](https://github.com/influxdata/influxdb-client-go/issues/344) `WriteAPI.Flush()` writes also batches from the retry queue.
 
 ## 2.9.1 [2022-06-24]
 ### Bug fixes

--- a/api/write.go
+++ b/api/write.go
@@ -109,10 +109,12 @@ func (w *WriteAPIImpl) Errors() <-chan error {
 	return w.errCh
 }
 
-// Flush forces all pending writes from the buffer to be sent
+// Flush forces all pending writes from the buffer to be sent.
+// Flush also tries sending batches from retry queue without additional retrying.
 func (w *WriteAPIImpl) Flush() {
 	w.bufferFlush <- struct{}{}
 	w.waitForFlushing()
+	w.service.Flush()
 }
 
 func (w *WriteAPIImpl) waitForFlushing() {

--- a/internal/test/http_service.go
+++ b/internal/test/http_service.go
@@ -27,7 +27,7 @@ type HTTPService struct {
 	lines          []string
 	t              *testing.T
 	wasGzip        bool
-	requestHandler func(c *HTTPService, url string, body io.Reader) error
+	requestHandler func(url string, body io.Reader) error
 	replyError     *http2.Error
 	lock           sync.Mutex
 }
@@ -40,6 +40,10 @@ func (t *HTTPService) WasGzip() bool {
 // SetWasGzip sets wasGzip flag
 func (t *HTTPService) SetWasGzip(wasGzip bool) {
 	t.wasGzip = wasGzip
+}
+
+func (t *HTTPService) SetRequestHandler(fn func(url string, body io.Reader) error) {
+	t.requestHandler = fn
 }
 
 // ServerURL returns testing URL
@@ -127,9 +131,9 @@ func (t *HTTPService) DoPostRequest(_ context.Context, url string, body io.Reade
 		return t.ReplyError()
 	}
 	if t.requestHandler != nil {
-		err = t.requestHandler(t, url, body)
+		err = t.requestHandler(url, body)
 	} else {
-		err = t.decodeLines(body)
+		err = t.DecodeLines(body)
 	}
 
 	if err != nil {
@@ -138,7 +142,7 @@ func (t *HTTPService) DoPostRequest(_ context.Context, url string, body io.Reade
 	return nil
 }
 
-func (t *HTTPService) decodeLines(body io.Reader) error {
+func (t *HTTPService) DecodeLines(body io.Reader) error {
 	bytes, err := ioutil.ReadAll(body)
 	if err != nil {
 		return err

--- a/log/logger.go
+++ b/log/logger.go
@@ -129,5 +129,5 @@ func (l *logger) Errorf(format string, v ...interface{}) {
 func (l *logger) Error(msg string) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
-	log.Print(l.prefix, " [E]! ", msg)
+	log.Print(l.prefix, " E! ", msg)
 }


### PR DESCRIPTION
Closes #340

## Proposed Changes

Added `internal/write/Service.Flush()` which instantaneously writes batches from the retry queue.
`WriteAPI.Flush()` also calls that.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

