### PR TITLE
fix: skip retrying on some errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 ### Features
 - [#348](https://github.com/influxdata/influxdb-client-go/pull/348) Added `write.Options.Consitency` parameter to support InfluxDB Enterprise.  
 
+### Bug fixes
+- [#349](https://github.com/influxdata/influxdb-client-go/pull/349) Skip retrying on specific write errors (mostly partial write error).
+
+
 ## 2.9.2 [2022-07-29]
 ### Bug fixes
 - [#341](https://github.com/influxdata/influxdb-client-go/pull/341) Changing logging level of messages about discarding batch to Error. 


### PR DESCRIPTION
## Proposed Changes

Skip retrying on specific write errors (mostly partial write errors).
Inspired by [Telegraf's InfluxDB output](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/influxdb/http.go#L401)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

