### PR TITLE
fix(WriteAPIBlocking): properly return error from flush()

### DIFF
--- a/api/writeAPIBlocking.go
+++ b/api/writeAPIBlocking.go
@@ -119,7 +119,9 @@ func (w *writeAPIBlocking) flush(ctx context.Context) error {
 		body := strings.Join(w.batch, "\n")
 		w.batch = w.batch[:0]
 		b := iwrite.NewBatch(body, w.writeOptions.MaxRetryTime())
-		return w.service.WriteBatch(ctx, b)
+		if err:= w.service.WriteBatch(ctx, b); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Commit https://github.com/influxdata/influxdb-client-go/pull/350/commits/a9c1e378757965a5e5bc81b7b5a3f09cbbdeec97 introduced a bug, where a successful `Flush` returns a non-nil error because the internal function (`w.service.WriteBatch`) returns a concrete pointer and not an `error`.

Closes #360 

This bug is not present without Batching because the return value of `WriteBatch()` is properly checked before returning from the function `writeAPIBlocking.write()`. This code path is skipped by delegating the work to `writeAPIBlocking.flush()` instead.

```go

func (w *writeAPIBlocking) write(ctx context.Context, line string) error {
	if atomic.LoadInt32(&w.batching) > 0 {
		w.mu.Lock()
		defer w.mu.Unlock()
		w.batch = append(w.batch, line)
		if len(w.batch) == int(w.writeOptions.BatchSize()) {
			return w.flush(ctx)
		} else {
			return nil
		}
	}
	err := w.service.WriteBatch(ctx, iwrite.NewBatch(line, w.writeOptions.MaxRetryTime()))
	if err != nil {
		return err
	}
	return nil
}
```
```go
// flush is unsychronized helper for creating and sending batch
// Must be called from synchronized block
func (w *writeAPIBlocking) flush(ctx context.Context) error {
	if len(w.batch) > 0 {
		body := strings.Join(w.batch, "\n")
		w.batch = w.batch[:0]
		b := iwrite.NewBatch(body, w.writeOptions.MaxRetryTime())
		return w.service.WriteBatch(ctx, b)
	}
	return nil
}
```

## Proposed Changes

check the concrete type for a `nil` pointer (of type `*http2.Error`) otherwise return an explicit `nil` error.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
