### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ There are also other examples in the API docs:
 
 1.  Add the client package your to your project dependencies (go.mod).
     ```sh
-    go get github.com/influxdata/influxdb-client-go/v2
+    go install github.com/influxdata/influxdb-client-go/v2@latest
     ```
 1. Add import `github.com/influxdata/influxdb-client-go/v2` to your source code.
 


### PR DESCRIPTION
I'm proposing the update command to install influxdb_client for go. With the command in the readme, the error is: 

<code>go get github.com/influxdata/influxdb-client-go/v2                                                   go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.</code>

Closes #

## Proposed Changes

This is the way of downloading an specific package: 

```
go install github.com/influxdata/influxdb-client-go/v2@latest
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
