### PR TITLE
fix: allowing proxy from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [unreleased]
 ### Bug fixes
+- [#368](https://github.com/influxdata/influxdb-client-go/pull/368) Allowing proxy from environment variable
 
 ## 2.12.1 [2022-12-01]
 ### Bug fixes

--- a/api/http/options.go
+++ b/api/http/options.go
@@ -40,6 +40,7 @@ func (o *Options) HTTPClient() *http.Client {
 		o.httpClient = &http.Client{
 			Timeout: time.Second * time.Duration(o.HTTPRequestTimeout()),
 			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				DialContext: (&net.Dialer{
 					Timeout: 5 * time.Second,
 				}).DialContext,

--- a/api/http/options_test.go
+++ b/api/http/options_test.go
@@ -6,6 +6,7 @@ package http_test
 
 import (
 	"crypto/tls"
+	"github.com/stretchr/testify/require"
 	nethttp "net/http"
 	"testing"
 	"time"
@@ -20,6 +21,9 @@ func TestDefaultOptions(t *testing.T) {
 	assert.Equal(t, uint(20), opts.HTTPRequestTimeout())
 	assert.NotNil(t, opts.HTTPClient())
 	assert.True(t, opts.OwnHTTPClient())
+	transport, ok := opts.HTTPClient().Transport.(*nethttp.Transport)
+	require.True(t, ok)
+	assert.NotNil(t, transport.Proxy)
 	assert.EqualValues(t, "", opts.ApplicationName())
 }
 


### PR DESCRIPTION
Closes #367 

## Proposed Changes

Added proxy to the client's custom HTTP transport. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

