### PR TITLE
chore(deps): remove deprecated pkg/errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [unreleased]
 
+### Bug fixes
+
 - [#386](https://github.com/influxdata/influxdb-client-go/pull/386) Remove deprecated pkg/errors
 - [#387](https://github.com/influxdata/influxdb-client-go/pull/387) Upgrade deepmap/oapi-codegen
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [unreleased]
 
-- [#386](https://github.com/influxdata/influxdb-client-go/pull/386)remove deprecated pkg/errors
-- [#387](https://github.com/influxdata/influxdb-client-go/pull/387)upgrade deepmap/oapi-codegen
+- [#386](https://github.com/influxdata/influxdb-client-go/pull/386) Remove deprecated pkg/errors
+- [#387](https://github.com/influxdata/influxdb-client-go/pull/387) Upgrade deepmap/oapi-codegen
 
 ## 2.12.3 [2023-03-29]
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+- [#386](https://github.com/influxdata/influxdb-client-go/pull/386)remove deprecated pkg/errors
+- [#387](https://github.com/influxdata/influxdb-client-go/pull/387)upgrade deepmap/oapi-codegen
+
 ## 2.12.3 [2023-03-29]
 ### Bug fixes
 - Update golang.org/x/net from 0.0.0-20210119194325-5f4716e94777 to 0.7.0

--- a/domain/client.gen.go
+++ b/domain/client.gen.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
-	"github.com/pkg/errors"
 )
 
 // Doer performs HTTP requests.

--- a/domain/templates/imports.tmpl
+++ b/domain/templates/imports.tmpl
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"gopkg.in/yaml.v3"
 	"io"
@@ -26,7 +27,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-chi/chi/v5"
 	"github.com/labstack/echo/v4"
-	"github.com/pkg/errors"
 	{{- range .ExternalImports}}
 	{{ . }}
 	{{- end}}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.17
 require (
 	github.com/deepmap/oapi-codegen v1.12.4
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1 // test dependency
 	golang.org/x/net v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=


### PR DESCRIPTION
Signed-off-by: andig <cpuidle@gmx.de>

## Proposed Changes

Remove deprecated pkg/errors. Depends on https://github.com/influxdata/influxdb-client-go/pull/387, needs rebase/tidy after https://github.com/influxdata/influxdb-client-go/pull/387 has been merged.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
