### PR TITLE
BUGFIX: ci image to include go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,14 @@
 # Golang CircleCI 2.0 configuration file
 #
-# Check https://circleci.com/docs/2.0/language-go/ for more details
+# Check https://circleci.com/docs/guides/getting-started/language-go/ for more details
 version: 2.1
+orbs:
+  go: circleci/go@4.0.0
 jobs:
   build:
-    machine:
-      image: cimg/go:1.25
+    executor:
+      name: go/default
+      tag: "1.22"
     environment:
       ENV: CI
       GO111MODULE: "on"
@@ -20,7 +23,9 @@ jobs:
             mkdir -p /tmp/artifacts
             mkdir -p /tmp/test-results
       - run: go version
-      - run: go get -v -t -d ./...
+      - go/with-cache:
+          steps:
+            - go/mod-download
       - run: make lint
       - run:
           name: "Start InfluxDB service"
@@ -45,3 +50,7 @@ jobs:
           destination: raw-test-output
       - store_test_results:
           path: /tmp/test-results
+workflows:
+  main:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2204:current
+      image: cimg/go:1.25
     environment:
       ENV: CI
       GO111MODULE: "on"
@@ -19,9 +19,6 @@ jobs:
           command: |
             mkdir -p /tmp/artifacts
             mkdir -p /tmp/test-results
-      - run: sudo rm -rf /usr/local/go
-      - run: wget https://golang.org/dl/go1.22.2.linux-amd64.tar.gz -O /tmp/go.tgz
-      - run: sudo tar -C /usr/local -xzf /tmp/go.tgz
       - run: go version
       - run: go get -v -t -d ./...
       - run: make lint


### PR DESCRIPTION
circle-ci is using a [deprecated](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/) image 'ubuntu-2004:202201-02'.

## Proposed Changes

cimg/go is a Docker image created by CircleCI with continuous integration builds in mind. Each tag contains a complete Go version and toolchain, the testing wrapper gotestsum, and any binaries and tools that are required for builds to complete successfully in a CircleCI environment.

## Checklist

- [x] Rebased/mergeable
- [ ] Tests pass (unable to test from PR)
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
