### PR TITLE
fix: update machine image ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:current
     environment:
       ENV: CI
       GO111MODULE: "on"
@@ -14,29 +14,29 @@ jobs:
       INFLUXDB2_ONBOARDING_URL: "http://localhost:8089"
     steps:
       - checkout
-#      - run:
-#          name: check tidy
-#          command: |
-#            go mod tidy
-#            if ! git --no-pager diff --exit-code -- go.mod go.sum; then
-#              echo modules are not tidy, please run 'go mod tidy'
-#              exit 1
-#            fi
-#      - run:
-#          name: check go fmt
-#          command: |
-#            go fmt
-#            if ! git --no-pager diff --exit-code -- go.mod go.sum; then
-#              echo modules are not tidy, please run 'go fmt ./...'
-#              exit 1
-#            fi
+      #      - run:
+      #          name: check tidy
+      #          command: |
+      #            go mod tidy
+      #            if ! git --no-pager diff --exit-code -- go.mod go.sum; then
+      #              echo modules are not tidy, please run 'go mod tidy'
+      #              exit 1
+      #            fi
+      #      - run:
+      #          name: check go fmt
+      #          command: |
+      #            go fmt
+      #            if ! git --no-pager diff --exit-code -- go.mod go.sum; then
+      #              echo modules are not tidy, please run 'go fmt ./...'
+      #              exit 1
+      #            fi
       - run:
           name: "Create a temp directory for artifacts"
           command: |
             mkdir -p /tmp/artifacts
             mkdir -p /tmp/test-results
       - run: sudo rm -rf /usr/local/go
-      - run: wget https://golang.org/dl/go1.20.1.linux-amd64.tar.gz -O /tmp/go.tgz
+      - run: wget https://golang.org/dl/go1.22.1.linux-amd64.tar.gz -O /tmp/go.tgz
       - run: sudo tar -C /usr/local -xzf /tmp/go.tgz
       - run: go version
       - run: go get -v -t -d ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             mkdir -p /tmp/artifacts
             mkdir -p /tmp/test-results
       - run: sudo rm -rf /usr/local/go
-      - run: wget https://golang.org/dl/go1.22.1.linux-amd64.tar.gz -O /tmp/go.tgz
+      - run: wget https://golang.org/dl/go1.22.2.linux-amd64.tar.gz -O /tmp/go.tgz
       - run: sudo tar -C /usr/local -xzf /tmp/go.tgz
       - run: go version
       - run: go get -v -t -d ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,22 +14,6 @@ jobs:
       INFLUXDB2_ONBOARDING_URL: "http://localhost:8089"
     steps:
       - checkout
-      #      - run:
-      #          name: check tidy
-      #          command: |
-      #            go mod tidy
-      #            if ! git --no-pager diff --exit-code -- go.mod go.sum; then
-      #              echo modules are not tidy, please run 'go mod tidy'
-      #              exit 1
-      #            fi
-      #      - run:
-      #          name: check go fmt
-      #          command: |
-      #            go fmt
-      #            if ! git --no-pager diff --exit-code -- go.mod go.sum; then
-      #              echo modules are not tidy, please run 'go fmt ./...'
-      #              exit 1
-      #            fi
       - run:
           name: "Create a temp directory for artifacts"
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.15.0 [unreleased]
 
+### Features
+- [#416](https://github.com/influxdata/influxdb-client-go/pull/416) update circleci machine image to ubuntu-2204:current  
+
 ## 2.14.0 [2024-08-12]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.15.0 [unreleased]
 
 ### Features
-- [#416](https://github.com/influxdata/influxdb-client-go/pull/416) update circleci machine image to ubuntu-2204:current  
+- [#416](https://github.com/influxdata/influxdb-client-go/pull/416) Update CircleCi machine image to `ubuntu-2204:current`  
 
 ## 2.14.0 [2024-08-12]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.15.0 [unreleased]
 
-### Features
+### CI
+
 - [#416](https://github.com/influxdata/influxdb-client-go/pull/416) Update CircleCi machine image to `ubuntu-2204:current`  
 
 ## 2.14.0 [2024-08-12]


### PR DESCRIPTION
Closes #

## Proposed Changes

_ Update circleci machine image to ubuntu-2204:current, the current one is deprecated
_ Update circleci build go version to 1.22.2, go version < 1.22.2 will cause error 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
