### PR TITLE
write/service: handle a nil URL from url.Parse without panicking

### DIFF
--- a/internal/write/service.go
+++ b/internal/write/service.go
@@ -73,17 +73,34 @@ func NewService(org string, bucket string, httpService http2.Service, options *w
 	if retryBufferLimit == 0 {
 		retryBufferLimit = 1
 	}
-	u, _ := url.Parse(httpService.ServerAPIURL())
-	u, _ = u.Parse("write")
-	params := u.Query()
-	params.Set("org", org)
-	params.Set("bucket", bucket)
-	params.Set("precision", precisionToString(options.Precision()))
-	if options.Consistency() != "" {
-		params.Set("consistency", string(options.Consistency()))
+	// If ServerAPIURL is malformed (e.g. the user passed an IP without a
+	// scheme to NewClient) url.Parse returns a nil URL. Treat that as
+	// "best effort" and build the URL by string concatenation so a later
+	// HTTP call surfaces the bad address as an error instead of panicking
+	// here. See issue #422.
+	var writeURL string
+	if u, err := url.Parse(httpService.ServerAPIURL()); err == nil && u != nil {
+		u, _ = u.Parse("write")
+		params := u.Query()
+		params.Set("org", org)
+		params.Set("bucket", bucket)
+		params.Set("precision", precisionToString(options.Precision()))
+		if options.Consistency() != "" {
+			params.Set("consistency", string(options.Consistency()))
+		}
+		u.RawQuery = params.Encode()
+		writeURL = u.String()
+	} else {
+		params := url.Values{}
+		params.Set("org", org)
+		params.Set("bucket", bucket)
+		params.Set("precision", precisionToString(options.Precision()))
+		if options.Consistency() != "" {
+			params.Set("consistency", string(options.Consistency()))
+		}
+		base := strings.TrimRight(httpService.ServerAPIURL(), "/")
+		writeURL = base + "/write?" + params.Encode()
 	}
-	u.RawQuery = params.Encode()
-	writeURL := u.String()
 	return &Service{
 		org:                  org,
 		bucket:               bucket,

--- a/internal/write/service_test.go
+++ b/internal/write/service_test.go
@@ -34,6 +34,27 @@ func TestPrecisionToString(t *testing.T) {
 	assert.Equal(t, "ns", precisionToString(time.Microsecond*20))
 }
 
+func TestNewService_MalformedServerURLDoesNotPanic(t *testing.T) {
+	// A server URL without a scheme (e.g. a bare host:port) makes
+	// url.Parse return a nil URL. NewService used to dereference it
+	// and panic; it should now build the write URL via string
+	// concatenation and surface the bad address later as an HTTP
+	// error instead. See #422.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NewService panicked: %v", r)
+		}
+	}()
+	hs := test.NewTestService(t, "192.168.1.104:8086/")
+	srv := NewService("org", "buc", hs, write.DefaultOptions())
+	if srv == nil {
+		t.Fatal("expected non-nil service")
+	}
+	if got := srv.WriteURL(); got == "" {
+		t.Fatal("expected a non-empty write URL")
+	}
+}
+
 func TestAddDefaultTags(t *testing.T) {
 	hs := test.NewTestService(t, "http://localhost:8888")
 	opts := write.DefaultOptions()


### PR DESCRIPTION
Fixes #422. `NewClient` accepts any string for `serverURL` and only stores it. A malformed value like a bare host:port (`192.168.1.104:8086`) makes `url.Parse` return `(nil, err)`. `internal/write.NewService` discards that error and immediately calls `u.Parse("write")` on the nil URL, panicking on first `WriteAPIBlocking` use.

Stack trace from the repro in the issue:

    net/url.(*URL).ResolveReference(0x0, ...)
    net/url.(*URL).Parse(0x0, "write")
    .../internal/write.NewService(...) service.go:77
    .../api.NewWriteAPIBlocking(...)
    .../v2.(*clientImpl).WriteAPIBlocking(...)

Fall back to building the write URL by string concatenation when `url.Parse` fails. The bad address still surfaces later when the HTTP request is dispatched, just as a regular network/HTTP error instead of a panic.

Added a regression test that constructs `NewService` with the broken URL from the issue.

Fixes #422