### PR TITLE
write/point: run convertField when AddField re-sets an existing key

### DIFF
--- a/api/write/point.go
+++ b/api/write/point.go
@@ -69,13 +69,14 @@ func (m *Point) AddTag(k, v string) *Point {
 
 // AddField adds a field to a point.
 func (m *Point) AddField(k string, v interface{}) *Point {
+	cv := convertField(v)
 	for i, field := range m.fields {
 		if k == field.Key {
-			m.fields[i].Value = v
+			m.fields[i].Value = cv
 			return m
 		}
 	}
-	m.fields = append(m.fields, &lp.Field{Key: k, Value: convertField(v)})
+	m.fields = append(m.fields, &lp.Field{Key: k, Value: cv})
 	return m
 }
 

--- a/api/write/point_test.go
+++ b/api/write/point_test.go
@@ -280,6 +280,16 @@ func TestEqualSignEscaping(t *testing.T) {
 	assert.Equal(t, "h=2o,l\\=ocation=e\\=urope l\\=evel=2i\n", line)
 }
 
+func TestAddFieldUpdateConvertsValue(t *testing.T) {
+	p := NewPointWithMeasurement("m")
+	p.AddField("x", int32(1))
+	// re-setting an existing field must run convertField too, otherwise
+	// the second value sits in field.Value as its raw type (int32 here)
+	// instead of the line-protocol canonical int64.
+	p.AddField("x", int32(2))
+	assert.Equal(t, int64(2), p.FieldList()[0].Value)
+}
+
 var s string
 
 func BenchmarkPointEncoderSingle(b *testing.B) {


### PR DESCRIPTION
Found while reading api/write/point.go.

`AddField` runs the input value through `convertField` when appending a new field, so e.g. `int32(5)` lands in the point as `int64(5)`, a `time.Time` as its RFC3339Nano string, etc. But the re-set path on the existing key did:

```go
m.fields[i].Value = v
```

with the raw `v`. So the canonical-type guarantee quietly disappeared on update. Easiest to see with non-`int64` ints, where the line-protocol encoder downstream expects `int64`:

```go
p := NewPointWithMeasurement("m")
p.AddField("x", int32(1))   // stored as int64(1) via convertField
p.AddField("x", int32(2))   // stored as int32(2)  !!
```

Pulled the convertField call out front so both branches use the same value. Added a regression test on the int32 case.