### PR TITLE
api/write: poll writeBuffer length, not the unbuffered info channel

### DIFF
--- a/api/write.go
+++ b/api/write.go
@@ -159,7 +159,7 @@ x:
 			w.flushBuffer()
 			break x
 		case buffInfo := <-w.bufferInfoCh:
-			buffInfo.writeBuffLen = len(w.bufferInfoCh)
+			buffInfo.writeBuffLen = len(w.writeBuffer)
 			w.bufferInfoCh <- buffInfo
 		}
 	}


### PR DESCRIPTION
Found while reading api/write.go.

WriteAPIImpl.waitForFlushing has two loops that send a request on an info channel and read the response back, breaking out once writeBuffLen hits 0. The bufferProc handler writes the response as:

```go
case buffInfo := <-w.bufferInfoCh:
    buffInfo.writeBuffLen = len(w.bufferInfoCh)
    w.bufferInfoCh <- buffInfo
```

bufferInfoCh is `make(chan writeBuffInfoReq)` (unbuffered), so its `len()` is always 0. The loop therefore breaks on its first iteration regardless of how much data is still sitting in `w.writeBuffer`. `w.writeBuffer` is the slice bufferProc owns and is what the wait was meant to be looking at.